### PR TITLE
#2204 Add `field` parameter to specify fields returned from API

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,7 @@ ignore = W291, E203, W503
 exclude =
     __pycache__
     node_modules
-		.venv
+    .venv
+    .direnv
 
 ; vim: ft=dosini

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 UNAME := $(shell uname)
 
 # what if we tagged with commit sha?
-NAME=955696714113.dkr.ecr.eu-west-2.amazonaws.com/digital-land-info
+REPO=955696714113.dkr.ecr.eu-west-2.amazonaws.com
+NAME=$(REPO)/digital-land-info
 TAG    := $$(git log -1 --pretty=%h)
 IMG    := ${NAME}:${TAG}
 LATEST := ${NAME}:latest
@@ -28,11 +29,11 @@ build:
 	docker build  --target production -t ${IMG} .
 	docker tag ${IMG} ${LATEST}
 
-push:
+push: login
 	docker push ${NAME}
 
 login:
-	aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $(DOCKER_IMAGE_URL)
+	aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $(REPO)
 
 test-acceptance:
 	python -m playwright install chromium
@@ -76,3 +77,6 @@ flake8:
 
 server-dev:
 	make -j 2 server frontend-watch
+
+load-db: login
+	docker-compose -f docker-compose.yml -f docker-compose.load-db.yml run load-db

--- a/README.md
+++ b/README.md
@@ -54,8 +54,19 @@ Assuming there's a running postgres available locally on localhost with a db cal
 use [https://github.com/digital-land/digital-land-postgres](https://github.com/digital-land/digital-land-postgres) to
 load entity data into the database.
 
-Check out the digital-land-postgres repo, ensure you have postgres running in docker-compose from this repo or on your machine and
-follow the instructions in the readme of digital-land-postgres repo.
+Run the following command to load data into the database used by docker compose:
+
+```
+make load-db
+```
+
+Note that you will have to be authenticated with AWS ECR in order to pull the` ``digital-land-postgres` image. If you are following the [AWS Authentication](#aws-authentication) instructions from below, it would be better to run:
+
+```
+aws-vault exec dl-dev -- make load-db
+```
+
+Once the database is loaded, run `docker-compose up` to start the service with a fresh database
 
 ### Run integration tests
 
@@ -77,7 +88,7 @@ If you want to see the acceptance tests in action run the following:
 
     playwright install chromium
     pytest tests/acceptance  --headed --slowmo 1000
-    
+
 
 --headed opens browser and --slowmo slows down interactions by the specified number of milliseconds
 

--- a/application/core/models.py
+++ b/application/core/models.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Optional, List
+from typing import Optional, List, Union
 from pydantic import BaseModel, Field
 
 from application.db.models import EntityOrm
@@ -99,8 +99,12 @@ class DatasetPublicationCountModel(DigitalLandBaseModel):
     publisher_count: int
 
 
-def entity_factory(entity_orm: EntityOrm):
-    e = EntityModel.from_orm(entity_orm)
+def entity_factory(entity: Union[EntityOrm, dict]):
+    if isinstance(entity, EntityOrm):
+        e = EntityModel.from_orm(entity)
+    else:
+        e = EntityModel.parse_obj(entity)
+
     if e.geojson is not None:
         e.geojson.properties = e.dict(exclude={"geojson"}, by_alias=True)
     return e

--- a/application/core/models.py
+++ b/application/core/models.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Optional, List, Union
+from typing import Optional, List
 from pydantic import BaseModel, Field
 
 from application.db.models import EntityOrm
@@ -99,12 +99,8 @@ class DatasetPublicationCountModel(DigitalLandBaseModel):
     publisher_count: int
 
 
-def entity_factory(entity: Union[EntityOrm, dict]):
-    if isinstance(entity, EntityOrm):
-        e = EntityModel.from_orm(entity)
-    else:
-        e = EntityModel.parse_obj(entity)
-
+def entity_factory(entity_orm: EntityOrm):
+    e = EntityModel.from_orm(entity_orm)
     if e.geojson is not None:
         e.geojson.properties = e.dict(exclude={"geojson"}, by_alias=True)
     return e

--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -65,9 +65,7 @@ def get_entity_search(parameters: dict):
             query_args = [getattr(EntityOrm, field.value) for field in only_fields]
         else:
             query_args = [EntityOrm]
-        query = session.query(
-            *query_args
-        )
+        query = session.query(*query_args)
         query = _apply_base_filters(query, params)
         query = _apply_date_filters(query, params)
         query = _apply_location_filters(session, query, params)
@@ -79,9 +77,7 @@ def get_entity_search(parameters: dict):
 
         if only_fields:
             entities = [
-                entity_factory(
-                    dict(zip([field.value for field in only_fields], entity_values))
-                )
+                dict(zip([field.value for field in only_fields], entity_values))
                 for entity_values in entities
             ]
         else:

--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -70,10 +70,10 @@ def get_entity_search(parameters: dict):
         query = _apply_date_filters(query, params)
         query = _apply_location_filters(session, query, params)
         query = _apply_entries_option_filter(query, params)
+        count = query.count()
         query = _apply_limit_and_pagination_filters(query, params)
 
         entities = query.all()
-        count = query.count()
 
         if only_fields:
             entities = [

--- a/application/search/filters.py
+++ b/application/search/filters.py
@@ -1,10 +1,17 @@
 import datetime
+from enum import Enum
 
 from dataclasses import dataclass
 from typing import Optional, List
 from fastapi import Query, Header
 
+from application.core.models import DatasetModel
 from application.search.enum import EntriesOption, DateOption, GeometryRelation, Suffix
+
+DATASET_MODEL_FIELDS = list(DatasetModel.schema()["properties"].keys())
+DATASET_MODEL_FIELD_ENUM = Enum(
+    "field", zip(DATASET_MODEL_FIELDS, DATASET_MODEL_FIELDS)
+)
 
 
 @dataclass
@@ -77,3 +84,6 @@ class QueryFilters:
         None, description="accepted content-type for results"
     )
     suffix: Optional[Suffix] = Query(None, description="file format for the results")
+    field: Optional[List[DATASET_MODEL_FIELD_ENUM]] = Query(
+        None, description="fields to be included in response"
+    )

--- a/docker-compose.load-db.yml
+++ b/docker-compose.load-db.yml
@@ -5,6 +5,7 @@ services:
     image: 955696714113.dkr.ecr.eu-west-2.amazonaws.com/digital-land-postgres
     depends_on:
       - db
+      - web
     environment:
       S3_KEY: entity-builder/dataset/entity.sqlite3
       DB_NAME: digital_land

--- a/docker-compose.load-db.yml
+++ b/docker-compose.load-db.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  load-db:
+    image: 955696714113.dkr.ecr.eu-west-2.amazonaws.com/digital-land-postgres
+    depends_on:
+      - db
+    environment:
+      S3_KEY: entity-builder/dataset/entity.sqlite3
+      DB_NAME: digital_land
+      DB_USER_NAME: postgres
+      DB_PASSWORD: postgres
+      DB_WRITE_ENDPOINT: db
+      S3_BUCKET: digital-land-production-collection-dataset

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       context: .
       dockerfile: Dockerfile
       target: dev
-    command: |
-      bash -c 'while !</dev/tcp/db/5432; do sleep 1; done; uvicorn application.app:app --reload --workers 1 --host 0.0.0.0 --port 8000'
     volumes:
       - .:/src
     ports:
@@ -17,6 +15,10 @@ services:
     environment:
       WRITE_DATABASE_URL: "postgresql://postgres:postgres@db/digital_land"
       READ_DATABASE_URL: "postgresql://postgres:postgres@db/digital_land"
+      PRE_START_PATH: /src/prestart-dev.sh
+      PORT: 8000
+      RELOAD: "true"
+      WEB_CONCURRENCY: 1
 
   db:
     image: postgis/postgis:13-master

--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -47,6 +47,7 @@ graceful_timeout = int(graceful_timeout_str)
 timeout = int(timeout_str)
 keepalive = int(keepalive_str)
 preload_app = True
+reload = os.getenv("RELOAD", "false").lower() == "true"
 
 
 # For debugging and testing

--- a/prestart-dev.sh
+++ b/prestart-dev.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while [[ ! cat < /dev/tcp/db/5432 ]]; do
+    sleep 1;
+done
+
+python -m alembic upgrade head

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -5,4 +5,4 @@ pre-commit
 playwright
 pytest-playwright
 black
-sqlalchemy_utils
+pytest-pudb

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -5,3 +5,4 @@ pre-commit
 playwright
 pytest-playwright
 black
+sqlalchemy_utils

--- a/tests/integration/test_entity_search.py
+++ b/tests/integration/test_entity_search.py
@@ -278,7 +278,7 @@ def test_search_includes_only_field_params(test_data, client, exclude_middleware
     response = client.get("/entity.json?limit=10&field=name")
     response.raise_for_status()
     result = response.json()
-    assert result["count"] > 0
+    assert result["count"] == 4
     e = result["entities"][0]
     assert not set(e.keys()).symmetric_difference(set(["name"]))
 
@@ -287,7 +287,7 @@ def test_search_includes_multiple_field_params(test_data, client, exclude_middle
     response = client.get("/entity.json?limit=10&field=name&field=dataset")
     response.raise_for_status()
     result = response.json()
-    assert result["count"] > 0
+    assert result["count"] == 4
     e = result["entities"][0]
     assert not set(e.keys()).symmetric_difference(set(["name", "dataset"]))
 
@@ -297,3 +297,10 @@ def test_search_pagination_does_not_affect_count(test_data, client, exclude_midd
     response.raise_for_status()
     result = response.json()
     assert result["count"] == 4
+
+
+def test_search_filtering_does_affect_count(test_data, client, exclude_middleware):
+    response = client.get("/entity.json?limit=1&dataset=greenspace")
+    response.raise_for_status()
+    result = response.json()
+    assert result["count"] == 1

--- a/tests/integration/test_entity_search.py
+++ b/tests/integration/test_entity_search.py
@@ -290,3 +290,10 @@ def test_search_includes_multiple_field_params(test_data, client, exclude_middle
     assert result["count"] > 0
     e = result["entities"][0]
     assert not set(e.keys()).symmetric_difference(set(["name", "dataset"]))
+
+
+def test_search_pagination_does_not_affect_count(test_data, client, exclude_middleware):
+    response = client.get("/entity.json?limit=1")
+    response.raise_for_status()
+    result = response.json()
+    assert result["count"] == 4

--- a/tests/integration/test_entity_search.py
+++ b/tests/integration/test_entity_search.py
@@ -274,15 +274,19 @@ def test_search_historical_entries(test_data, params):
     assert "greenspace" == e.dataset
 
 
-def test_search_include_only_field_params(
-    test_data, params, client, exclude_middleware
-):
-
-    params["field"] = ["name"]
-
+def test_search_includes_only_field_params(test_data, client, exclude_middleware):
     response = client.get("/entity.json?limit=10&field=name")
     response.raise_for_status()
     result = response.json()
     assert result["count"] > 0
     e = result["entities"][0]
     assert not set(e.keys()).symmetric_difference(set(["name"]))
+
+
+def test_search_includes_multiple_field_params(test_data, client, exclude_middleware):
+    response = client.get("/entity.json?limit=10&field=name&field=dataset")
+    response.raise_for_status()
+    result = response.json()
+    assert result["count"] > 0
+    e = result["entities"][0]
+    assert not set(e.keys()).symmetric_difference(set(["name", "dataset"]))

--- a/tests/integration/test_entity_search.py
+++ b/tests/integration/test_entity_search.py
@@ -42,6 +42,7 @@ def raw_params():
         "limit": 10,
         "offset": None,
         "suffix": None,
+        "field": None,
     }
 
 
@@ -271,3 +272,17 @@ def test_search_historical_entries(test_data, params):
     assert 1 == result["count"]
     e = result["entities"][0]
     assert "greenspace" == e.dataset
+
+
+def test_search_include_only_field_params(
+    test_data, params, client, exclude_middleware
+):
+
+    params["field"] = ["name"]
+
+    response = client.get("/entity.json?limit=10&field=name")
+    response.raise_for_status()
+    result = response.json()
+    assert result["count"] > 0
+    e = result["entities"][0]
+    assert not set(e.keys()).symmetric_difference(set(["name"]))


### PR DESCRIPTION
* When `field` querystring parameter is present (at leaset once), the only fields returned will be those specified in one of the `field` querystring arguments.
* Also added make target to load data from `digital-land-production-collection-dataset` using `digital-land-postgres`
* Fix prestart script execution in dev by removing `CMD` override, allowing [parent docker image `CMD`](https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/master/docker-images/start.sh#L23) to execute `$PRE_START_PATH`