### PR TITLE
Validate that dataset given in querystring argument exists

### DIFF
--- a/application/exceptions.py
+++ b/application/exceptions.py
@@ -1,0 +1,6 @@
+class DatasetValueNotFound(ValueError):
+    dataset_names: list
+
+    def __init__(self, *args, dataset_names: list, **kwargs):
+        self.dataset_names = dataset_names
+        super().__init__(*args, **kwargs)

--- a/application/search/filters.py
+++ b/application/search/filters.py
@@ -95,7 +95,9 @@ class QueryFilters:
         if not v:
             return v
         with get_context_session() as session:
-            dataset_names = session.query(DatasetOrm.dataset).all()
+            dataset_names = [
+                result[0] for result in session.query(DatasetOrm.dataset).all()
+            ]
         missing_datasets = set(v).difference(set(dataset_names))
         if missing_datasets:
             raise DatasetValueNotFound(

--- a/application/search/filters.py
+++ b/application/search/filters.py
@@ -1,11 +1,14 @@
 import datetime
 from enum import Enum
 
-from dataclasses import dataclass
 from typing import Optional, List
 from fastapi import Query, Header
+from pydantic import validator
+from pydantic.dataclasses import dataclass
 
 from application.core.models import EntityModel
+from application.db.models import DatasetOrm
+from application.db.session import get_context_session
 from application.search.enum import EntriesOption, DateOption, GeometryRelation, Suffix
 
 ENTITY_MODEL_FIELDS = list(EntityModel.schema()["properties"].keys())
@@ -85,3 +88,16 @@ class QueryFilters:
     field: Optional[List[ENTITY_MODEL_FIELD_ENUM]] = Query(
         None, description="fields to be included in response"
     )
+
+    @validator("dataset")
+    def datasets_exist(cls, v: Optional[list]):
+        if not v:
+            return v
+        with get_context_session() as session:
+            dataset_names = session.query(DatasetOrm.dataset).all()
+        missing_datasets = set(v).difference(set(dataset_names))
+        if missing_datasets:
+            raise ValueError(
+                f"Requested datasets do not exist: {','.join(missing_datasets)}"
+            )
+        return v

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -22,9 +22,7 @@ def _transform_dataset_fixture_to_response(datasets):
 
 def test_app_returns_valid_geojson_list(client):
 
-    response = client.get(
-        "/entity.geojson?dataset=not-real", headers={"Origin": "localhost"}
-    )
+    response = client.get("/entity.geojson", headers={"Origin": "localhost"})
     data = response.json()
     assert "type" in data
     assert "features" in data

--- a/tests/integration/test_entity_search.py
+++ b/tests/integration/test_entity_search.py
@@ -59,6 +59,59 @@ def test_search_entity_by_dataset_name_not_in_system(test_data, params):
     assert [] == result["entities"]
 
 
+def test_search_entity_by_dataset_name_not_in_system_returns_error(
+    test_data, client, exclude_middleware
+):
+    response = client.get("/entity.json?dataset=not-exists")
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": [
+            {
+                "ctx": {
+                    "dataset_names": [
+                        "greenspace",
+                        "forest",
+                        "brownfield-site",
+                        "historical-monument",
+                    ]
+                },
+                "loc": ["dataset"],
+                "msg": "Requested datasets do not exist: not-exists. Valid "
+                "dataset names: "
+                "greenspace,forest,brownfield-site,historical-monument",
+                "type": "value_error.datasetvaluenotfound",
+            }
+        ]
+    }
+
+
+def test_search_entity_by_dataset_names_not_in_system_returns_only_missing(
+    test_data, client, exclude_middleware
+):
+    response = client.get("/entity.json?dataset=not-exists&dataset=greenspace")
+    assert response.status_code == 400
+
+    assert response.json() == {
+        "detail": [
+            {
+                "ctx": {
+                    "dataset_names": [
+                        "greenspace",
+                        "forest",
+                        "brownfield-site",
+                        "historical-monument",
+                    ]
+                },
+                "loc": ["dataset"],
+                "msg": "Requested datasets do not exist: not-exists. Valid "
+                "dataset names: "
+                "greenspace,forest,brownfield-site,historical-monument",
+                "type": "value_error.datasetvaluenotfound",
+            }
+        ]
+    }
+
+
 def test_search_entity_by_single_dataset_name(test_data, params):
 
     params["dataset"] = ["greenspace"]


### PR DESCRIPTION
If it doesn't, return a nice helpful validation message with a list of datasets that do exist

Trello Card: https://trello.com/c/82Ldl1Fu/2260-for-entity-endpoint-when-dataset-argument-specified-validate-values-exists-and-return-error-if-not

If anyone's got any thoughts as to why the dataclass validator exceptions aren't being reraised as `RequestValidationError` rather than `ValidationError` (see [here](https://fastapi.tiangolo.com/tutorial/handling-errors/#override-request-validation-exceptions) for the difference) then i'm all ears