### PR TITLE
Add API to redirect to hoisted CSV file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+S3_HOISTED_BUCKET=https://digital-land-production-collection-dataset-hoisted.s3.eu-west-2.amazonaws.com
 S3_COLLECTION_BUCKET=https://digital-land-production-collection-dataset.s3.eu-west-2.amazonaws.com
 READ_DATABASE_URL=postgresql://postgres:postgres@localhost/digital_land
 WRITE_DATABASE_URL=postgresql://postgres:postgres@localhost/digital_land

--- a/.env.test.docker
+++ b/.env.test.docker
@@ -1,3 +1,4 @@
+S3_HOISTED_BUCKET=https://digital-land-production-collection-dataset-hoisted.s3.eu-west-2.amazonaws.com
 S3_COLLECTION_BUCKET=https://digital-land-production-collection-dataset.s3.eu-west-2.amazonaws.com
 READ_DATABASE_URL=postgresql://postgres:postgres@db/digital_land_test
 WRITE_DATABASE_URL=postgresql://postgres:postgres@db/digital_land_test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,6 +52,7 @@ jobs:
       env:
         DATASETTE_URL:  https://datasette.digital-land.info
         S3_COLLECTION_BUCKET: https://digital-land-production-collection-dataset.s3.eu-west-2.amazonaws.com
+        S3_HOISTED_BUCKET: https://digital-land-production-collection-dataset-hoisted.s3.eu-west-2.amazonaws.com
         READ_DATABASE_URL: postgresql://postgres:postgres@localhost/digital_land_test
         WRITE_DATABASE_URL: postgresql://postgres:postgres@localhost/digital_land_test
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-integration:
 	python -m pytest tests/integration --junitxml=.junitxml/integration.xml
 
 test-integration-docker:
-	docker-compose run web python -m pytest tests/integration --junitxml=.junitxml/integration.xml
+	docker-compose run web python -m pytest tests/integration --junitxml=.junitxml/integration.xml $(PYTEST_RUNTIME_ARGS)
 
 lint:	black-check flake8
 

--- a/application/routers/dataset.py
+++ b/application/routers/dataset.py
@@ -59,6 +59,7 @@ def get_dataset(
     settings: Settings = Depends(get_settings),
 ):
     collection_bucket = settings.S3_COLLECTION_BUCKET
+    hoisted_bucket = settings.S3_HOISTED_BUCKET
     try:
         _dataset = get_dataset_query(dataset)
         entity_count = get_entity_count(dataset)
@@ -71,6 +72,7 @@ def get_dataset(
                 "request": request,
                 "dataset": _dataset,
                 "collection_bucket": collection_bucket,
+                "hoisted_bucket": hoisted_bucket,
                 "entity_count": entity_count[1] if entity_count else 0,
                 "publishers": {
                     "expected": publisher_coverage.expected_publisher_count,

--- a/application/routers/dataset.py
+++ b/application/routers/dataset.py
@@ -101,7 +101,8 @@ def link_dataset(
 ):
     hoisted_collection_bucket = settings.S3_HOISTED_BUCKET
     return RedirectResponse(
-        urljoin(hoisted_collection_bucket, f"{dataset}-hoisted.csv"), status_code=302
+        urljoin(hoisted_collection_bucket, f"{dataset.dataset}-hoisted.csv"),
+        status_code=302,
     )
 
 

--- a/application/routers/dataset.py
+++ b/application/routers/dataset.py
@@ -1,8 +1,9 @@
 import logging
 from typing import Optional
+from urllib.parse import urljoin
 
 from fastapi import APIRouter, Request, Depends
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 
 from application.data_access.digital_land_queries import (
     get_dataset_query,
@@ -10,11 +11,11 @@ from application.data_access.digital_land_queries import (
     get_latest_resource,
     get_publisher_coverage,
 )
-
 from application.data_access.entity_queries import get_entity_count
 from application.core.templates import templates
 from application.core.utils import DigitalLandJSONResponse
-from application.search.enum import Suffix
+from application.search.enum import Suffix, SuffixLinkableFiles
+from application.search.filters import DatasetQueryFilters
 from application.settings import get_settings, Settings
 
 router = APIRouter()
@@ -92,6 +93,18 @@ def get_dataset(
         )
 
 
+def link_dataset(
+    request: Request,
+    extension: SuffixLinkableFiles,
+    dataset: DatasetQueryFilters = Depends(),
+    settings: Settings = Depends(get_settings),
+):
+    hoisted_collection_bucket = settings.S3_HOISTED_BUCKET
+    return RedirectResponse(
+        urljoin(hoisted_collection_bucket, f"{dataset}-hoisted.csv"), status_code=302
+    )
+
+
 router.add_api_route(
     ".{extension}",
     endpoint=list_datasets,
@@ -113,4 +126,11 @@ router.add_api_route(
     endpoint=get_dataset,
     response_class=HTMLResponse,
     include_in_schema=False,
+)
+
+router.add_api_route(
+    "/{dataset}.{extension}/link",
+    endpoint=link_dataset,
+    response_class=RedirectResponse,
+    tags=["Link dataset"],
 )

--- a/application/search/enum.py
+++ b/application/search/enum.py
@@ -1,6 +1,10 @@
 from enum import Enum
 
 
+class SuffixLinkableFiles(str, Enum):
+    csv = "csv"
+
+
 class Suffix(str, Enum):
     json = "json"
     html = "html"

--- a/application/search/filters.py
+++ b/application/search/filters.py
@@ -24,7 +24,10 @@ class DatasetQueryFilters:
     def datasets_exist(cls, dataset: str):
         with get_context_session() as session:
             dataset_names = [
-                result[0] for result in session.query(DatasetOrm.dataset).all()
+                result[0]
+                for result in session.query(DatasetOrm.dataset)
+                .where(DatasetOrm.typology != "specification")
+                .all()
             ]
         if dataset not in dataset_names:
             raise DatasetValueNotFound(

--- a/application/search/filters.py
+++ b/application/search/filters.py
@@ -17,6 +17,25 @@ ENTITY_MODEL_FIELD_ENUM = Enum("field", zip(ENTITY_MODEL_FIELDS, ENTITY_MODEL_FI
 
 
 @dataclass
+class DatasetQueryFilters:
+    dataset: str = Query(None)
+
+    @validator("dataset", pre=True)
+    def datasets_exist(cls, dataset: str):
+        with get_context_session() as session:
+            dataset_names = [
+                result[0] for result in session.query(DatasetOrm.dataset).all()
+            ]
+        if dataset not in dataset_names:
+            raise DatasetValueNotFound(
+                f"Requested dataset does not exist: {dataset}. "
+                f"Valid dataset names: {','.join(dataset_names)}",
+                dataset_names=dataset_names,
+            )
+        return dataset
+
+
+@dataclass
 class QueryFilters:
 
     # base filters

--- a/application/settings.py
+++ b/application/settings.py
@@ -1,12 +1,13 @@
 from dotenv import load_dotenv
-from pydantic import BaseSettings, PostgresDsn
+from pydantic import BaseSettings, PostgresDsn, HttpUrl
 from pydantic.tools import lru_cache
 
 load_dotenv()
 
 
 class Settings(BaseSettings):
-    S3_COLLECTION_BUCKET: str
+    S3_HOISTED_BUCKET: HttpUrl
+    S3_COLLECTION_BUCKET: HttpUrl
     WRITE_DATABASE_URL: PostgresDsn
     READ_DATABASE_URL: PostgresDsn
 

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -78,7 +78,7 @@
 
       <h2 class="govuk-heading-m" id="national-dataset-map">Download the data</h2>
       <p class="govuk-body">
-        Download a copy of this dataset as <a class="govuk-link" href="{{ collection_bucket }}/{{dataset["dataset"]}}-collection/dataset/{{ dataset["dataset"] }}.csv">CSV</a>,
+        Download a copy of this dataset as <a class="govuk-link" href="{{ hoisted_bucket }}/{{ dataset["dataset"] }}-hoisted.csv">CSV</a>,
         <a class="govuk-link" href="/entity.json?dataset={{ dataset['dataset'] }}">JSON</a>
         {% if dataset['typology'] == 'geography' %}
          or <a class="govuk-link" href="/entity.geojson?dataset={{ dataset['dataset'] }}">GeoJSON</a>

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -86,3 +86,17 @@ def test_get_dataset_endpoint_returns_as_expected(client, exclude_middleware):
     """
     response = client.get("/dataset/waste-authority")
     assert response.status_code == 200
+
+
+def test_link_dataset_endpoint_returns_as_expected(
+    test_data, test_settings, client, exclude_middleware
+):
+    """
+    Test link dataset endpoint returns a 302 response code with the S3_HOISTED_BUCKET domain
+    """
+    response = client.get("/dataset/greenspace.csv/link", allow_redirects=False)
+    assert response.status_code == 302
+    assert (
+        response.headers["location"]
+        == f"{test_settings.S3_HOISTED_BUCKET}/greenspace-hoisted.csv"
+    )


### PR DESCRIPTION
Trello Card: https://trello.com/c/lTxje8xi/2228-flatten-the-json-fields-so-that-they-are-all-top-level-values

* Exposes a `/dataset/{dataset name}.csv/link` endpoint which returns a 302 response redirecting to hoisted CSV
* IF `dataset_name` does not exist, or has `typology=specification` an HTTP error code will be returned