### PR TITLE
Ensure entity redirect uses suffix if exists

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -63,7 +63,7 @@ jobs:
         report_paths: '.junitxml/*.xml'
 
     - name: Configure AWS credentials
-      if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'  }}
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DL_WEB }}
@@ -71,11 +71,11 @@ jobs:
         aws-region: eu-west-2
 
     - name: Login to ECR
-      if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'  }}
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Build and tag
+    - name: Build and tag as latest
       if: ${{ github.ref == 'refs/heads/main' }}
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -84,7 +84,17 @@ jobs:
       run: |
         docker build --target production -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
 
-    - name: Push to ECR
+    - name: Build and tag as staging
+      if: ${{ github.ref == 'refs/heads/staging' }}
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: digital-land-info
+        IMAGE_TAG: staging
+      run: |
+        docker build --target production -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+
+
+    - name: Push to ECR as latest
       if: ${{ github.ref == 'refs/heads/main' }}
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -93,8 +103,21 @@ jobs:
       run: |
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-    - name: Restart digital-land.info service
+    - name: Push to ECR as staging
+      if: ${{ github.ref == 'refs/heads/staging' }}
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: digital-land-info
+        IMAGE_TAG: staging
+      run: |
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+    - name: Restart digital-land.info service on production environment
       if: ${{ github.ref == 'refs/heads/main' }}
       run: |
-        aws ecs update-service --force-new-deployment --service staging-web-service --cluster staging-web-cluster
         aws ecs update-service --force-new-deployment --service production-web-service --cluster production-web-cluster
+
+    - name: Restart digital-land.info service on staging environment
+      if: ${{ github.ref == 'refs/heads/staging' }}
+      run: |
+        aws ecs update-service --force-new-deployment --service staging-web-service --cluster staging-web-cluster

--- a/application/routers/entity.py
+++ b/application/routers/entity.py
@@ -45,7 +45,12 @@ def get_entity(request: Request, entity: int, extension: Optional[Suffix] = None
             },
         )
     elif old_entity_status == 301:
-        return RedirectResponse(f"/entity/{new_entity_id}", status_code=301)
+        if extension:
+            return RedirectResponse(
+                f"/entity/{new_entity_id}.{extension}", status_code=301
+            )
+        else:
+            return RedirectResponse(f"/entity/{new_entity_id}", status_code=301)
     elif e is not None:
 
         if extension is not None and extension.value == "json":

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -74,6 +74,20 @@ def test_old_entity_redirects_as_expected(
     assert response.headers["location"] == f"/entity/{old_entity.new_entity_id}"
 
 
+def test_old_entity_redirects_as_expected_with_suffix(
+    test_data_old_entities, client, exclude_middleware
+):
+    """
+    Test entity endpoint returns a 302 response code when old_entity requested
+    """
+    old_entity = test_data_old_entities["old_entities"][301][0]
+    response = client.get(
+        f"/entity/{old_entity.old_entity_id}.json", allow_redirects=False
+    )
+    assert response.status_code == 301
+    assert response.headers["location"] == f"/entity/{old_entity.new_entity_id}.json"
+
+
 def test_old_entity_gone_shown(test_data_old_entities, client, exclude_middleware):
     """
     Test entity endpoint returns entity gone content


### PR DESCRIPTION
* Fix and add test against issue where redirect omits the suffix even if included, so `/entity/1.json` -> `/entity/2`
* For push to staging branch, tag and push staging docker image to ECR and initiate staging deploy