### PR TITLE
Support DATABASE_URL if it exists, for compatability with gov.uk PaaS

### DIFF
--- a/.env.dev.docker
+++ b/.env.dev.docker
@@ -1,7 +1,7 @@
 ENVIRONMENT="development"
 S3_HOISTED_BUCKET=https://digital-land-production-collection-dataset-hoisted.s3.eu-west-2.amazonaws.com
 S3_COLLECTION_BUCKET=https://digital-land-production-collection-dataset.s3.eu-west-2.amazonaws.com
-DATABASE_URL="postgresql://postgres:postgres@db/digital_land"
+DATABASE_URL="postgres://postgres:postgres@db/digital_land"
 PRE_START_PATH=/src/prestart-dev.sh
 PORT=8000
 RELOAD="true"

--- a/.env.dev.docker
+++ b/.env.dev.docker
@@ -1,6 +1,7 @@
 ENVIRONMENT="development"
-WRITE_DATABASE_URL="postgresql://postgres:postgres@db/digital_land"
-READ_DATABASE_URL="postgresql://postgres:postgres@db/digital_land"
+S3_HOISTED_BUCKET=https://digital-land-production-collection-dataset-hoisted.s3.eu-west-2.amazonaws.com
+S3_COLLECTION_BUCKET=https://digital-land-production-collection-dataset.s3.eu-west-2.amazonaws.com
+DATABASE_URL="postgresql://postgres:postgres@db/digital_land"
 PRE_START_PATH=/src/prestart-dev.sh
 PORT=8000
 RELOAD="true"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -81,14 +81,14 @@ jobs:
       env:
         IMAGE_TAG: latest
       run: |
-        make EXPLICIT_TAG=$IMAGE_TAG docker-build-private
+        make EXPLICIT_TAG=$IMAGE_TAG docker-build
 
     - name: Build and tag as staging
       if: ${{ github.ref == 'refs/heads/staging' }}
       env:
         IMAGE_TAG: staging
       run: |
-        make EXPLICIT_TAG=$IMAGE_TAG docker-build-private docker-build-public
+        make EXPLICIT_TAG=$IMAGE_TAG docker-build
 
     - name: Push to ECR as latest
       if: ${{ github.ref == 'refs/heads/main' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN pip install --user --no-cache-dir -r requirements/requirements.txt
 
 EXPOSE 80
 
-ENV PATH=/root/.local:$PATH
+ENV PATH=/root/.local/bin:$PATH
 ENV MODULE_NAME=application.app
 ENV GUNICORN_CONF=/src/gunicorn_conf.py
 ENV PRE_START_PATH=/src/prestart.sh

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ TAG    := $$(git log -1 --pretty=%h)
 IMG    := ${NAME}:${TAG}
 LATEST := ${NAME}:latest
 
-CF_APP_NAME := digital-land-platform
+CF_BASE_APP_NAME := digital-land-platform
 
 PUBLIC_REPO   := public.ecr.aws/l6z6v3j6
-PUBLIC_NAME   := $(PUBLIC_REPO)/$(CF_APP_NAME)
+PUBLIC_NAME   := $(PUBLIC_REPO)/$(CF_BASE_APP_NAME)
 PUBLIC_TAG    := $$(git log -1 --pretty=%h)
 PUBLIC_IMG    := ${PUBLIC_NAME}:${PUBLIC_TAG}
 PUBLIC_LATEST := ${PUBLIC_NAME}:latest
@@ -125,4 +125,4 @@ ifeq (, $(ENVIRONMENT))
 	$(error "No environment specified via $$ENVIRONMENT, please pass as make argument")
 endif
 	cf target -o dluhc-digital-land -s $(ENVIRONMENT)
-	cf push $(CF_APP_NAME)
+	cf push $(ENVIRONMENT)-$(CF_BASE_APP_NAME)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ server:
 	echo $$OBJC_DISABLE_INITIALIZE_FORK_SAFETY
 	gunicorn -w 2 -k uvicorn.workers.UvicornWorker application.app:app --preload --forwarded-allow-ips="*"
 
-build: docker-build-private docker-build-public
+docker-build: docker-build-private docker-build-public
 
 docker-build-private:
 	docker build  --target production -t $(EXPLICIT_IMG) .

--- a/application/factory.py
+++ b/application/factory.py
@@ -91,14 +91,12 @@ def add_base_routes(app):
             with get_context_session() as session:
                 sql = select(EntityOrm.entity).limit(1)
                 result = session.execute(sql).fetchone()
-                if result is not None:
-                    status = {
-                        "status": "OK",
-                    }
-                    logger.info(f"healthcheck {status}")
-                    return status
-                else:
-                    raise Exception("Error fetching entities")
+                status = {
+                    "status": "OK",
+                    "entities_present": "OK" if result is not None else "FAIL",
+                }
+                logger.info(f"healthcheck {status}")
+                return status
         except Exception as e:
             logger.exception(e)
             raise e

--- a/application/settings.py
+++ b/application/settings.py
@@ -1,3 +1,4 @@
+import os
 from functools import lru_cache
 from typing import Optional
 
@@ -18,4 +19,12 @@ class Settings(BaseSettings):
 
 @lru_cache()
 def get_settings() -> Settings:
-    return Settings()
+    # Gov.uk PaaS provides a URL to the postgres instance it provisions via DATABASE_URL
+    # See https://docs.cloud.service.gov.uk/deploying_services/postgresql/#connect-to-a-postgresql-service-from-your-app
+    if "DATABASE_URL" in os.environ:
+        return Settings(
+            READ_DATABASE_URL=os.environ["DATABASE_URL"],
+            WRITE_DATABASE_URL=os.environ["DATABASE_URL"],
+        )
+    else:
+        return Settings()

--- a/application/settings.py
+++ b/application/settings.py
@@ -22,9 +22,9 @@ def get_settings() -> Settings:
     # Gov.uk PaaS provides a URL to the postgres instance it provisions via DATABASE_URL
     # See https://docs.cloud.service.gov.uk/deploying_services/postgresql/#connect-to-a-postgresql-service-from-your-app
     if "DATABASE_URL" in os.environ:
-        return Settings(
-            READ_DATABASE_URL=os.environ["DATABASE_URL"],
-            WRITE_DATABASE_URL=os.environ["DATABASE_URL"],
+        database_url = os.environ["DATABASE_URL"].replace(
+            "postgres://", "postgresql://", 1
         )
+        return Settings(READ_DATABASE_URL=database_url, WRITE_DATABASE_URL=database_url)
     else:
         return Settings()

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: digital-land-platform
+- name: staging-digital-land-platform
   docker:
     image: public.ecr.aws/l6z6v3j6/digital-land-platform:latest
     username: null
@@ -9,10 +9,3 @@ applications:
   health-check-http-endpoint: /health
   health-check-invocation-timeout: 180
   timeout: 180
-  env:
-    LOG_LEVEL: debug
-    ENVIRONMENT: staging
-    DATASETTE_URL: https://staging-datasette.digital-land.info/
-    S3_COLLECTION_BUCKET: https://digital-land-staging-collection-dataset.s3.eu-west-2.amazonaws.com
-    S3_HOISTED_BUCKET: https://digital-land-staging-collection-dataset-hoisted.s3.eu-west-2.amazonaws.com
-    # WRITE_DATABASE_URL and READ_DATABASE_URL also need to be added. Their values can be found in AWS

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -36,7 +36,10 @@ def run_migrations_offline():
     script output.
     """
 
-    url = os.getenv("WRITE_DATABASE_URL")
+    if "DATABASE_URL" in os.environ:
+        url = os.getenv("DATABASE_URL")
+    else:
+        url = os.getenv("WRITE_DATABASE_URL")
     logging.info(f"Running offline migration against {url}")
     context.configure(
         url=url,

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -37,7 +37,7 @@ def run_migrations_offline():
     """
 
     if "DATABASE_URL" in os.environ:
-        url = os.getenv("DATABASE_URL")
+        url = os.environ["DATABASE_URL"].replace("postgres://", "postgresql://", 1)
     else:
         url = os.getenv("WRITE_DATABASE_URL")
     logging.info(f"Running offline migration against {url}")


### PR DESCRIPTION
* Support `DATABASE_URL` if it exists, use to populate `WRITE_DATABASE_URL` and `READ_DATABASE_URL` in settings
    * gov.uk PaaS provides `DATABASE_URL` to app environment where that app is provisioned with a postgres backing service
    * string replacement is necessary due to SQLAlchemy deprecating `postgres://` protocol specifier in favour of `postgresql://`. See [here](https://docs.sqlalchemy.org/en/14/changelog/changelog_14.html#change-3687655465c25a39b968b4f5f6e9170b) for details
* Modify healthcheck response so that the app returns 200 when started on unpopulated database. 
    * Needed to successfully start app on gov.uk PaaS
    * Returns the presence of entities as a parameter
    * Separate PR to modify healthcheck to check this parameter and alert on missing entities https://github.com/digital-land/smoke-test/pull/1
* Remove environment definition, to enable terraform to be single source of truth for environment variables and to allow for deployment (with existing env) without population of secret values
* Modify app name in makefile to account for environment specifier on app name (needed to avoid namespace collision in default route URL)