### PR TITLE
add fix for pagination buttons

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
     - id: black
 

--- a/application/templates/search.html
+++ b/application/templates/search.html
@@ -232,14 +232,38 @@
           </ul>
           <!-- /.app-results-list -->
 
+          {% if prev_url and next_url %}
           <div class="app-pagination__wrapper govuk-!-margin-bottom-7">
           {{ appPagination({
             "next": {
               "href": next_url,
               "text": "Show next "+ limit|string + " entities"
+            },
+            "prev":{
+              "href":prev_url,
+              "text": "Show previous "+ limit|string + " entities"
             }
           }) }}
           </div>
+          {% elif next_url %}
+          <div class="app-pagination__wrapper govuk-!-margin-bottom-7">
+            {{ appPagination({
+              "next": {
+                "href": next_url,
+                "text": "Show next "+ limit|string + " entities"
+              }
+            }) }}
+          </div>
+          {% elif prev_url %}
+          <div class="app-pagination__wrapper govuk-!-margin-bottom-7">
+            {{ appPagination({
+              "prev": {
+                "href": prev_url,
+                "text": "Show previous "+ limit|string + " entities"
+              }
+            }) }}
+          </div>
+          {% endif %}
           <!-- /.app-pagination__wrapper -->
 
           {# Anything within this div becomes 'sticky' to the bottom upon scroll #}


### PR DESCRIPTION
Used the make links function to retrieve next and previous page links. This is now used in all of the outputs (html/geojson/json) so moved to top of the search_entities function.

Also updated the version of black that is being used for pre-commits as it was failing for me because of a known issue with the black version being used.