### PR TITLE
add not named to map where entities are not named

### DIFF
--- a/assets/javascripts/dl-national-map-controller.js
+++ b/assets/javascripts/dl-national-map-controller.js
@@ -104,11 +104,17 @@ MapController.prototype.createFeaturesPopup = function (features) {
   features.forEach(function (feature) {
     var featureType = capitalizeFirstLetter(feature.sourceLayer).replaceAll('-', ' ');
     var fillColour = that.getFillColour(feature);
+
+    var featureName = feature.properties.name
+    if (featureName === ''){
+      featureName = 'Not Named'
+    }
+
     var itemHTML = [
       "<li class=\"app-popup-item\" style=\"border-left: 5px solid ".concat(fillColour, "\">"),
       "<p class=\"app-secondary-text govuk-!-margin-bottom-0 govuk-!-margin-top-0\">".concat(featureType, "</p>"),
       '<p class="dl-small-text govuk-!-margin-top-0 govuk-!-margin-bottom-0">',
-      "<a class='govuk-link' href=\"/entity/".concat(feature.properties.entity, "\">").concat(feature.properties.name, "</a>"),
+      "<a class='govuk-link' href=\"/entity/".concat(feature.properties.entity, "\">").concat(featureName, "</a>"),
       '</p>',
       '</li>'
     ];


### PR DESCRIPTION
there's a lot of data that isn't named in the source data. For these the map doesn't link through as there's no text to attach a hyperlink to. I have added an if clause to check for this in the map controller js. it fills in Not Named as a value, this should be easy change if we want to replace it with a different field in the future.