### PR TITLE
Fix/use reference as name

### DIFF
--- a/application/templates/entity.html
+++ b/application/templates/entity.html
@@ -7,7 +7,7 @@
 {%- from "digital-land-frontend/components/data-reference-cell/macro.jinja" import dlDataReferenceCell %}
 {%- from "digital-land-frontend/components/data-table/macro.jinja" import dlDataTableWrapper %}
 
-{%- set row_name = row['name'] if row['name'] else "Entity " ~ row['entity'] %}
+{%- set row_name = row['name'] if row['name'] else row['reference'] %}
 {% set geometry_url = "/entity/" + row["entity"] | string + ".geojson" if row['typology'] == "geography" else
   None %}
 {% if geometry_url or geojson_features %}

--- a/application/templates/entity.html
+++ b/application/templates/entity.html
@@ -7,7 +7,14 @@
 {%- from "digital-land-frontend/components/data-reference-cell/macro.jinja" import dlDataReferenceCell %}
 {%- from "digital-land-frontend/components/data-table/macro.jinja" import dlDataTableWrapper %}
 
-{%- set row_name = row['name'] if row['name'] else row['reference'] %}
+{% if row['name'] %}
+  {%- set row_name = row['name'] %}
+{%- elif row['reference'] %}
+  {%- set row_name = row['reference'] %}
+{%- else %}
+  {%- set row_name = "Not Named" %}
+{%- endif %}
+
 {% set geometry_url = "/entity/" + row["entity"] | string + ".geojson" if row['typology'] == "geography" else
   None %}
 {% if geometry_url or geojson_features %}

--- a/assets/javascripts/dl-national-map-controller.js
+++ b/assets/javascripts/dl-national-map-controller.js
@@ -106,8 +106,13 @@ MapController.prototype.createFeaturesPopup = function (features) {
     var fillColour = that.getFillColour(feature);
 
     var featureName = feature.properties.name
+    var featureReference = feature.properties.reference
     if (featureName === ''){
-      featureName = 'Not Named'
+      if (featureReference === ''){
+        featureName = 'Not Named'
+      } else {
+        featureName = featureReference
+      }
     }
 
     var itemHTML = [


### PR DESCRIPTION
Ensure that reference is used where no name is present, on both the map and entity pages. In the unlikely example where there is no name or reference is available 'Not Named' is displayed.