### PR TITLE
Feat: sentry release logging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ docker-compose.override.yml
 *.md
 tests
 tf
+.venv
 .pytest_cache
 .env
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ ENV PATH=/root/.local/bin:$PATH
 ENV MODULE_NAME=application.app
 ENV GUNICORN_CONF=/src/gunicorn_conf.py
 ENV PRE_START_PATH=/src/prestart.sh
+ARG RELEASE_TAG
+ENV RELEASE_TAG=${RELEASE_TAG}
 
 FROM production AS dev
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ server:
 	gunicorn -w 2 -k uvicorn.workers.UvicornWorker application.app:app --preload --forwarded-allow-ips="*"
 
 docker-build:
-	docker build  --target production -t $(EXPLICIT_IMG) .
+	docker build --build-arg RELEASE_TAG=$(COMMIT_TAG) --target production -t $(EXPLICIT_IMG) .
 	docker tag $(EXPLICIT_IMG) $(COMMIT_IMG)
 
 push: docker-login

--- a/application/factory.py
+++ b/application/factory.py
@@ -243,6 +243,7 @@ def add_middleware(app):
             dsn=settings.SENTRY_DSN,
             environment=settings.ENVIRONMENT,
             traces_sample_rate=settings.SENTRY_TRACE_SAMPLE_RATE,
+            release=settings.RELEASE_TAG,
         )
         app.add_middleware(SentryAsgiMiddleware)
 

--- a/application/settings.py
+++ b/application/settings.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     READ_DATABASE_URL: PostgresDsn
     SENTRY_DSN: Optional[str] = None
     SENTRY_TRACE_SAMPLE_RATE: Optional[float] = 0.1
+    RELEASE_TAG: Optional[str] = None
     ENVIRONMENT: str
 
 


### PR DESCRIPTION
*What?*
* Bake the short commit hash into docker images.
* Use the baked-in commit hash as the release tag in sentry.

*Why?*
So when exceptions show up in sentry and changes in performance show which change they are related to.