### PR TITLE
alter fact queries to be more defensive

### DIFF
--- a/application/routers/fact.py
+++ b/application/routers/fact.py
@@ -93,7 +93,9 @@ def search_facts(
 
         facts_dicts = [fact.dict(by_alias=True) for fact in facts]
 
-        dataset_fields = get_dataset_fields(dataset=query_params["dataset"])
+        dataset_fields = get_dataset_fields(
+            dataset=query_params["dataset"], entity=query_params["entity"]
+        )
         dataset_fields_dict = [
             dataset_field.dict(by_alias=True) for dataset_field in dataset_fields
         ]


### PR DESCRIPTION
add retries to bad requests form datasette, this should help stop requests from timing out. Altered the dataset fields query to take an entity as an optimal parameter. This speeds up the query but we may want a more permanent solution for retrieving dataset field names.