### PR TITLE
Fix/security scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -176,3 +176,42 @@ jobs:
                 }
               ]
             }
+
+  check-audit-errors:
+    runs-on: ubuntu-latest
+    needs:
+      - dynamic-audit
+      - static-audit
+    if: always() && contains(join(needs.*.result, ','), 'failure')
+    steps:
+      - name: send failure notification
+        uses: slackapi/slack-github-action@v1
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: 'dl-developers'
+          payload: |
+            {
+              "text": "Security Scan: digital-land.info",
+              "icon_emoji": ":alert:",
+              "username": "SecurityScanner",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Security Scan Failed: digital-land.info"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The report for this scan is available on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: setup
         run: |
-          sudo apt-get update
-          sudo apt-get install -y docker-compose
+          sudo curl -SL https://github.com/docker/compose/releases/download/v2.10.2/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
           docker pull ${DOCKER_REPO}/${APPLICATION}:${DOCKER_APPLICATION_TAG}
 
       - name: attack

--- a/docker-compose.security.yml
+++ b/docker-compose.security.yml
@@ -2,10 +2,6 @@ version: "3.8"
 
 services:
   web:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
     ports:
       - "8000:8000"
     depends_on:

--- a/docker-compose.security.yml
+++ b/docker-compose.security.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    image: public.ecr.aws/l6z6v3j6/digital-land-platform:${DOCKER_APPLICATION_TAG-staging}
+    image: public.ecr.aws/l6z6v3j6/digital-land-platform:${DOCKER_APPLICATION_TAG-latest}
     environment:
       ENVIRONMENT: production
       S3_HOISTED_BUCKET: https://digital-land-production-collection-dataset-hoisted.s3.eu-west-2.amazonaws.com

--- a/docker-compose.security.yml
+++ b/docker-compose.security.yml
@@ -16,6 +16,7 @@ services:
       DATASETTE_URL: https://datasette.digital-land.info
       PORT: 8000
       WEB_CONCURRENCY: 1
+      DATA_FILE_URL: https://data.digital-land.info
     healthcheck:
       test: curl -v -i -f http://localhost:8000
       interval: 1s

--- a/zap.yaml
+++ b/zap.yaml
@@ -9,20 +9,6 @@ env:
     progressToStdout: true
 
 jobs:
-  - type: addOns
-    install:
-      - ascanrules
-      - ascanrulesAlpha
-      - ascanrulesBeta
-      - pscanrulesBeta
-      - pscanrulesAlpha
-      - automation
-      - domxss
-      - openapi
-      - reflect
-      - reports
-      - spiderAjax
-
   - type: passiveScan-config
     parameters:
       maxAlertsPerRule: 10


### PR DESCRIPTION
*What?*

Fix the current failing scheduled security scan and add feature to notify in slack on failure.

*Why?*

A new environment variable was added to the application but no follow up was posted to the slack channel when the scan failed.

*How?*

Added the new variable to the security scan, and updated to use the current docker image in prod instead of building our own. Also added a job with condition: `if: always() && contains(join(needs.*.result, ','), 'failure')` to run and notify in slack if the scan fails for any reason.