### PR TITLE
Disable service alert

### DIFF
--- a/application/templates/layouts/layout--full-width.html
+++ b/application/templates/layouts/layout--full-width.html
@@ -7,7 +7,7 @@
 
 {% block mastHead %}
   {% set fullWidthHeader = true %}
-  <article class="app-service-alert">
+  {# <article class="app-service-alert">
     <div class="govuk-width-container">
       <p class="app-service-alert__text">
         <span class="app-service-alert__icon" aria-hidden="true">!</span>
@@ -15,7 +15,7 @@
         <a href="/service-status" class="app-service-alert__link">Tuesday 22nd November 2022 at 14:00 GMT</a>.
       </p>
     </div>
-  </article>
+  </article> #}
   {% include 'partials/mast-head.html' %}
 {% endblock mastHead %}
 

--- a/application/templates/layouts/layout.html
+++ b/application/templates/layouts/layout.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block mastHead %}
-  <article class="app-service-alert">
+  {# <article class="app-service-alert">
     <div class="govuk-width-container">
       <p class="app-service-alert__text">
         <span class="app-service-alert__icon" aria-hidden="true">!</span>
@@ -29,7 +29,7 @@
         <a href="/service-status" class="app-service-alert__link">Tuesday 22nd November 2022 at 14:00 GMT</a>.
       </p>
     </div>
-  </article>
+  </article> #}
   {% include 'partials/mast-head.html' %}
 {% endblock mastHead %}
 

--- a/application/templates/pages/service-status.md
+++ b/application/templates/pages/service-status.md
@@ -1,10 +1,5 @@
 ## Planned maintenance
 
-### When
-Tuesday 22nd November 2022 at 2PM (14:00 GMT)
+We have no maintenance planned.
 
-### What is the impact?
-The planning.data.gov.uk site and some related services will be unavailable (down) for up to two hours.
-
-### Why are we doing this work?
-This work is needed to improve our current service infrastructure.
+You can email: <a href="mailto:{{ templateVar.email }}">{{ templateVar.email }}</a> to tell us if there is a problem with this service.

--- a/application/templates/pages/service-status.md
+++ b/application/templates/pages/service-status.md
@@ -1,5 +1,3 @@
-## Planned maintenance
-
-We have no maintenance planned.
+## We have no maintenance planned
 
 You can email: <a href="mailto:{{ templateVar.email }}">{{ templateVar.email }}</a> to tell us if there is a problem with this service.


### PR DESCRIPTION
For when the DNS has updated and we no longer need to advise users of a possible problem with the service availability. 