### PR TITLE
update links from data to dataset

### DIFF
--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -147,14 +147,14 @@
         <nav role="navigation" aria-labelledby="download-the-data">
           <ul class="govuk-list govuk-!-font-size-16">
             <li>
-              <a class="govuk-link" href="{{ data_file_url }}/data/{{ dataset["dataset"] }}.csv">CSV</a>
+              <a class="govuk-link" href="{{ data_file_url }}/dataset/{{ dataset["dataset"] }}.csv">CSV</a>
             </li>
             <li>
-              <a class="govuk-link" href="{{ data_file_url }}/data/{{ dataset['dataset'] }}.json">JSON</a>
+              <a class="govuk-link" href="{{ data_file_url }}/dataset/{{ dataset['dataset'] }}.json">JSON</a>
             </li>
             {% if dataset['typology'] == 'geography' %}
             <li>
-              <a class="govuk-link" href="{{ data_file_url }}/data/{{ dataset['dataset'] }}.geojson">GeoJSON</a>
+              <a class="govuk-link" href="{{ data_file_url }}/dataset/{{ dataset['dataset'] }}.geojson">GeoJSON</a>
             </li>
             {% endif %}
           </ul>


### PR DESCRIPTION
what?
update links on dataset page so they lead to the correct place.

why?
in the change of infrastructure the folder contianing the relevant data may have moved, hence we need to reflect this.