### PR TITLE
Remove database offset from entity query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docker-compose.override.yml
 coverage.xml
 .secrets
 unit-tests.md
+integration-tests.md

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ That will install all dependencies, both python and node front end build tools a
 The pre commit hooks will lint and run black and abort a commit on failure.  This will save you lots of broken builds
 and subsequent "lint fix" commit messages.
 
+NOTE: If you see an error like
+>Error: Node Sass does not yet support your current environment: Linux 64-bit with Unsupported runtime (111)<
+
+then the chances are that you version of Node is wrong for this project. Run `nvm install`  which will install the version listed in the .nvmrc file. re-run `make init` afterwards.
+
 ### Postgres setup
 
 **Mac users**

--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -276,9 +276,10 @@ def _apply_entries_option_filter(query, params):
 
 
 def _apply_limit_and_pagination_filters(query, params):
-    query = query.order_by(EntityOrm.entity)
-    if params.get("limit") is not None:
-        query = query.limit(params["limit"])
+    # Use offset passed in to filter records with greater
+    # entity id. Possibly more efficient than using a database offset.
     if params.get("offset") is not None:
-        query = query.offset(params["offset"])
+        query = query.filter(EntityOrm.entity > params["offset"])
+    query = query.order_by(EntityOrm.entity)
+    query = query.limit(params.get("limit"))
     return query

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 filterwarnings =
     ignore::DeprecationWarning
     ignore::sqlalchemy.exc.SAWarning
+log_cli = true
+log_cli_level = WARN

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,3 @@
 filterwarnings =
     ignore::DeprecationWarning
     ignore::sqlalchemy.exc.SAWarning
-log_cli = true
-log_cli_level = WARN

--- a/tests/unit/data_access/test_entity_queries.py
+++ b/tests/unit/data_access/test_entity_queries.py
@@ -1,5 +1,9 @@
 from sqlalchemy.orm import Query
-from application.data_access.entity_queries import _apply_limit_and_pagination_filters
+from application.data_access.entity_queries import (
+    _apply_limit_and_pagination_filters,
+    get_entity_search,
+)
+from application.db.session import get_context_session
 from application.db.models import EntityOrm
 
 
@@ -7,3 +11,98 @@ def test__apply_limit_and_pagination_filters_with_no_filters_applied():
     query = Query(EntityOrm)
     result = _apply_limit_and_pagination_filters(query, params={"dataset": "testing"})
     assert result._limit_clause is None
+
+
+dataset_name = "test-dataset"
+base_id = 1000
+
+
+def tidy():
+    with get_context_session() as session:
+        session.query(EntityOrm).filter(EntityOrm.dataset == dataset_name).delete()
+        session.commit()
+
+
+def setupDB():
+    """
+    Create a dataset with
+    + a discontinuous series of IDs (entity column)
+    + and the rows not all inserted in increasing order
+    """
+
+    with get_context_session() as session:
+
+        for num in range(1, 24):
+            e1 = EntityOrm(
+                entity=base_id + num, name=f"S01Entity{num+1:04}", dataset=dataset_name
+            )
+            session.add(e1)
+
+        for num in range(73, 95):
+            e2 = EntityOrm(
+                entity=base_id + num, name=f"S02Entity{num+1:04}", dataset=dataset_name
+            )
+            session.add(e2)
+
+        for num in range(43, 55):
+            e3 = EntityOrm(
+                entity=base_id + num, name=f"S03Entity{num+1:04}", dataset=dataset_name
+            )
+            session.add(e3)
+
+        session.commit()
+
+
+def test__apply_limit_and_pagination_filters_only():
+    """
+    Create a dataset, and page through it, gathering the entity values (IDs) for each row.
+    Make sure no values are seen twice.
+    Make sure all values in db are actually collected in paged data.
+    """
+    tidy()
+    setupDB()
+
+    allSeen = []  # Add the entities we have seen whilst paging through the dataset
+    last = 0  # tracks the last entity id we got. Used in get_entity_search below.
+
+    search = get_entity_search(
+        parameters={"dataset": [dataset_name], "offset": last, "limit": 10}
+    )
+    entities = search.get(
+        "entities"
+    )  # there are also count and params in the returned search object.
+
+    while len(entities) == 10:
+        search = get_entity_search(
+            parameters={"dataset": [dataset_name], "offset": last, "limit": 10}
+        )
+        entities = search.get("entities")
+
+        newValues = [x.entity for x in entities]
+
+        # Make sure no values are seen twice.
+        for value in newValues:
+            assert value not in allSeen
+
+        allSeen = allSeen + newValues
+        assert len(allSeen) > 0
+
+        allSeen.sort()
+
+        last = entities[-1].entity
+
+    # Make sure all values in db are actually collected in paged data.
+    with get_context_session() as session:
+        allEntities = (
+            session.query(EntityOrm.entity)
+            .filter(EntityOrm.dataset == dataset_name)
+            .all()
+        )
+
+        allEntityIds = [x.entity for x in allEntities]
+
+    diffs = list(set(allEntityIds).difference(allSeen))
+    assert len(diffs) == 0
+    assert len(allEntityIds) == len(allSeen)
+
+    tidy()

--- a/tests/unit/data_access/test_entity_queries.py
+++ b/tests/unit/data_access/test_entity_queries.py
@@ -1,3 +1,4 @@
+import pytest
 from sqlalchemy.orm import Query
 from application.data_access.entity_queries import (
     _apply_limit_and_pagination_filters,
@@ -17,13 +18,15 @@ dataset_name = "test-dataset"
 base_id = 1000
 
 
-def tidy():
+@pytest.fixture
+def remove_entities():
     with get_context_session() as session:
         session.query(EntityOrm).filter(EntityOrm.dataset == dataset_name).delete()
         session.commit()
 
 
-def setupDB():
+@pytest.fixture
+def create_entities():
     """
     Create a dataset with
     + a discontinuous series of IDs (entity column)
@@ -53,14 +56,16 @@ def setupDB():
         session.commit()
 
 
-def test__apply_limit_and_pagination_filters_only():
+def test__apply_limit_and_pagination_filters_only(
+    test_data, remove_entities, create_entities
+):
     """
     Create a dataset, and page through it, gathering the entity values (IDs) for each row.
     Make sure no values are seen twice.
     Make sure all values in db are actually collected in paged data.
     """
-    tidy()
-    setupDB()
+    # tidy()
+    # setupDB()
 
     allSeen = []  # Add the entities we have seen whilst paging through the dataset
     last = 0  # tracks the last entity id we got. Used in get_entity_search below.
@@ -104,5 +109,3 @@ def test__apply_limit_and_pagination_filters_only():
     diffs = list(set(allEntityIds).difference(allSeen))
     assert len(diffs) == 0
     assert len(allEntityIds) == len(allSeen)
-
-    tidy()


### PR DESCRIPTION
Remove database offset from entity query.

Instead use pagination offset parameter to filter for records with entity id greater than current page offset.

Limit already defaults (via filter to 10) so no need for limit none check, and validator asserts limit max is 500.