### PR TITLE
Add robotx.txt exclusions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,12 @@ javascripts:
 	npm run nps build.javascripts
 	cp assets/javascripts/dl-national-map-controller.js static/javascripts/
 
-frontend: javascripts
+robots:
+	cp assets/robots.txt static/robots.txt
+
+frontend:
+	make javascripts
+	make robots
 	npm run nps build.stylesheets
 	rsync -r assets/images static/
 

--- a/application/factory.py
+++ b/application/factory.py
@@ -8,7 +8,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import ValidationError
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
@@ -270,6 +270,10 @@ def add_routers(app):
 
 
 def add_static(app):
+    @app.get("/robots.txt", response_class=FileResponse)
+    def robots():
+        return FileResponse("static/robots.txt")
+
     app.mount(
         "/static",
         StaticFiles(directory="static"),

--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: https://datasette.planning.data.gov.uk/
+Disallow: http://www.planning.data.gov.uk/entity/?dataset


### PR DESCRIPTION
We don't have a robots.txt file which can be used to ask search engine crawlers to exclude certain parts of the web sire. We've been seeing page fetches for rows in the 500,000 range which are almost certainly crawlers that we want to discourage for now.

This change adds a couple of paths in our sub site from being crawled. See the Disallow entries in robots.txt.

There may be more sections we want to exclude. Please comment appropriately and I'll add them.

There's away of testing this stuff but it requires adding custom files to the site for google/bing to confirm site ownership. We can have a look at that at some point.