### PR TITLE
Update how robots.txt is served - exclude it from Fast API

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -185,6 +185,10 @@ def add_base_routes(app):
             },
         )
 
+    @app.get("/robots.txt", response_class=FileResponse, include_in_schema=False)
+    def robots():
+        return FileResponse("static/robots.txt")
+
     @app.exception_handler(StarletteHTTPException)
     async def custom_404_exception_handler(
         request: Request, exc: StarletteHTTPException
@@ -270,9 +274,6 @@ def add_routers(app):
 
 
 def add_static(app):
-    @app.get("/robots.txt", response_class=FileResponse)
-    def robots():
-        return FileResponse("static/robots.txt")
 
     app.mount(
         "/static",


### PR DESCRIPTION
My initial cut of the robots.txt server route did not explicitly tell Fast API to exclude it from application API schema.

This update

1.  Explicitly excludes robots.txt from the schema generation
2. Moves the route to the base routes served by the application.

The first change has the effect of fixing the reported defect. Screenshot below.

![image](https://github.com/digital-land/digital-land.info/assets/124677903/55e60552-75b0-426f-a53d-8e778feee9ad)

Next step: Add the `https://www.planning.data.gov.uk/openapi.json` path to the Canaries checker.

