### PR TITLE
Documentation page status check

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -38,7 +38,7 @@ filelock==3.4.0
     # via virtualenv
 flake8==4.0.1
     # via -r requirements/dev-requirements.in
-greenlet==1.1.2
+greenlet==2.0.2
     # via
     #   -c requirements/requirements.txt
     #   playwright
@@ -80,7 +80,7 @@ platformdirs==2.4.0
     # via
     #   black
     #   virtualenv
-playwright==1.17.2
+playwright==1.35.0
     # via
     #   -r requirements/dev-requirements.in
     #   pytest-playwright
@@ -94,7 +94,7 @@ py==1.11.0
     # via pytest
 pycodestyle==2.8.0
     # via flake8
-pyee==8.2.2
+pyee==9.0.4
     # via playwright
 pyflakes==2.4.0
     # via flake8

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -62,7 +62,7 @@ gitpython==3.1.31
     # via -r requirements/requirements.in
 govuk-frontend-jinja==2.0.0
     # via digital-land-frontend
-greenlet==1.1.2
+greenlet==2.0.2
     # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements/requirements.in

--- a/tests/acceptance/test_acceptance.py
+++ b/tests/acceptance/test_acceptance.py
@@ -62,6 +62,11 @@ def test_acceptance(server_process, page, test_data):
     page.click("text=Datasets")
     assert page.url == f"{BASE_URL}/dataset/"
 
+    page.click("text=Documentation")
+    assert page.url == f"{BASE_URL}/docs"
+    assert page.text_content("h1") == "Documentation"
+    page.goto(BASE_URL)
+
 
 @pytest.mark.skip(reason="fixture to populate of data in test db not implemented yet")
 def test_get_json(server_process):
@@ -98,3 +103,11 @@ def test_documentation_page(page: Page):
     )
     expect(page).to_have_url(re.compile(".*docs"))
     expect(page).to_have_title(re.compile("Documentation - Planning Data"))
+
+
+def test_documentation_page_error(page: Page):
+    page.goto(BASE_URL + "/docs")
+
+    expect(page).not_to_have_title(
+        re.compile("There is a problem with the service - Planning Data")
+    )


### PR DESCRIPTION
Tests checks if the Documentation page has loaded with HTTP status 200 or if the Documentation page has loaded with an error message(verified by regenerating the error occurred earlier).

Reports error in case of status other than 200 with suitable error message
![Screenshot (279)](https://github.com/digital-land/digital-land.info/assets/110816640/8b817f4a-c7c5-45c3-98d7-da4a559f8fbb)

Playwright version updated to use expect() function.