### PR TITLE
75 add playwright test for maps that went missing

### DIFF
--- a/application/templates/components/map/macro.jinja
+++ b/application/templates/components/map/macro.jinja
@@ -10,6 +10,7 @@
         class="dl-map{{ ' ' + params.classes if params.classes }}"
         id="{{ params.id if params.id else 'map' }}"
         data-module="{{ params.dataModule if params.dataModule else 'boundary-map' }}"
+        data-testid="{{ params.testid if params.testid else 'map' }}"
         {%- if params.arialabelledby %} aria-labelledby="{{ ariaId }}"{% endif -%}
         {% if params.attributes -%}
         {%- for attribute, value in params.attributes.items() %} {{ attribute }}="{{ value if not value|is_list else value|join(';') }}"{% endfor %}
@@ -50,6 +51,7 @@
     id="{{ params.id if params.id else 'map' }}"
     data-module="{{ params.dataModule if params.dataModule else 'boundary-map' }}"
     style="height: {{ height }};"
+    data-testid="{{ params.testid if params.testid else 'map' }}"
     {%- if params.arialabelledby %} aria-labelledby="{{ ariaId }}"{% endif -%}
     {% if params.attributes -%}
     {%- for attribute, value in params.attributes.items() %} {{ attribute }}="{{ value if not value|is_list else value|join(';') }}"{% endfor %}

--- a/tests/acceptance/test_entity.py
+++ b/tests/acceptance/test_entity.py
@@ -1,0 +1,63 @@
+import pytest
+
+import time
+import re
+
+import uvicorn
+
+from multiprocessing.context import Process
+
+from application.app import create_app  # noqa: E402
+
+app = create_app()
+
+HOST = "0.0.0.0"
+PORT = 9000
+ENTITY_ROUTE = "/entity/"
+BASE_URL = f"http://{HOST}:{PORT}"
+
+
+def run_server():
+    uvicorn.run(app, host=HOST, port=PORT)
+
+
+@pytest.fixture(scope="session")
+def server_process():
+    proc = Process(target=run_server, args=(), daemon=True)
+    proc.start()
+    time.sleep(10)
+    yield proc
+    proc.kill()
+
+
+def test_correctly_loads_the_entity_root(server_process, page):
+    page.goto(BASE_URL + ENTITY_ROUTE)
+    assert page.title() == "Search for planning data"
+    resultsText = page.locator(".app-results-summary__title").inner_text()
+    assert re.match(r"\d+ results", resultsText)
+
+    # check if the leafletjs script has been loaded
+    page.evaluate_handle("L")
+
+    # check if the map control elements have been made (indicating the leaflet js has been loaded)
+    # this is quite long, perhaps consider a better way to do this
+    mapControls = page.locator(
+        "//*[contains(@class, 'app-card app-card--result')]//div[contains(@class, 'app-card__media')]//div//div//div[contains(@class, 'leaflet-control-container')]"  # noqa: E501
+    )
+    assert mapControls.count() > 1
+
+
+def test_correctly_loads_an_entity_page(server_process, page):
+    page.goto(BASE_URL + ENTITY_ROUTE + "1")
+
+    # check if the leafletjs script has been loaded
+    page.evaluate_handle("L")
+
+    # check if the map js object has been made
+    page.evaluate_handle("mapComponent")
+
+    # check if the map control element have been made (indicating the leaflet js has been loaded)
+    mapControls = page.locator(
+        "//div[@id='dlMap']//div[contains(@class, 'leaflet-control-container')]"
+    )
+    assert mapControls.count() == 1

--- a/tests/acceptance/test_entity.py
+++ b/tests/acceptance/test_entity.py
@@ -62,7 +62,3 @@ def test_correctly_loads_an_entity_page(server_process, page):
         "//div[contains(@class, 'leaflet-control-container')]"
     )
     assert mapControls.count() == 1
-
-
-def test_filter_entities(server_process, page):
-    assert page.title() == "Search for planning data"

--- a/tests/acceptance/test_entity.py
+++ b/tests/acceptance/test_entity.py
@@ -39,10 +39,8 @@ def test_correctly_loads_the_entity_root(server_process, page):
     # check if the leafletjs script has been loaded
     page.evaluate_handle("L")
 
-    # check if the map control elements have been made (indicating the leaflet js has been loaded)
-    # this is quite long, perhaps consider a better way to do this
-    mapControls = page.locator(
-        "//*[contains(@class, 'app-card app-card--result')]//div[contains(@class, 'app-card__media')]//div//div//div[contains(@class, 'leaflet-control-container')]"  # noqa: E501
+    mapControls = page.get_by_test_id("map").locator(
+        "//div[contains(@class, 'leaflet-control-container')]"
     )
     assert mapControls.count() > 1
 
@@ -60,4 +58,11 @@ def test_correctly_loads_an_entity_page(server_process, page):
     mapControls = page.locator(
         "//div[@id='dlMap']//div[contains(@class, 'leaflet-control-container')]"
     )
+    mapControls = page.get_by_test_id("map").locator(
+        "//div[contains(@class, 'leaflet-control-container')]"
+    )
     assert mapControls.count() == 1
+
+
+def test_filter_entities(server_process, page):
+    assert page.title() == "Search for planning data"

--- a/tests/acceptance/test_entity.py
+++ b/tests/acceptance/test_entity.py
@@ -39,6 +39,7 @@ def test_correctly_loads_the_entity_root(server_process, page):
     # check if the leafletjs script has been loaded
     page.evaluate_handle("L")
 
+    # check if the mapControls element has been added to the page, indicating the js has been executed
     mapControls = page.get_by_test_id("map").locator(
         "//div[contains(@class, 'leaflet-control-container')]"
     )
@@ -51,13 +52,7 @@ def test_correctly_loads_an_entity_page(server_process, page):
     # check if the leafletjs script has been loaded
     page.evaluate_handle("L")
 
-    # check if the map js object has been made
-    page.evaluate_handle("mapComponent")
-
-    # check if the map control element have been made (indicating the leaflet js has been loaded)
-    mapControls = page.locator(
-        "//div[@id='dlMap']//div[contains(@class, 'leaflet-control-container')]"
-    )
+    # check if the mapControls element has been added to the page, indicating the js has been executed
     mapControls = page.get_by_test_id("map").locator(
         "//div[contains(@class, 'leaflet-control-container')]"
     )


### PR DESCRIPTION
Ticket: [https://trello.com/c/yVxlUc96/75-add-playwright-test-for-maps-that-went-missing](https://trello.com/c/yVxlUc96/75-add-playwright-test-for-maps-that-went-missing)

added two tests one to check the search page, the other to check the entity page.

this will probably be rewritten/modified once we have some user stories to base these tests on. (see that ticket [here](https://trello.com/c/R9Y6pwdb/186-add-acceptance-tests-to-didgital-landinfo))