### PR TITLE
fix dl.info requirements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - run: make init
       - run: make lint
 
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - run: make init
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: 3.9
       - run: make init
       - run: make lint
 
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: 3.9
 
       - run: make init
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.10
       - run: make init
       - run: make lint
 
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.10
 
       - run: make init
 

--- a/.github/workflows/deply-to-dev.yml
+++ b/.github/workflows/deply-to-dev.yml
@@ -9,7 +9,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.10
       - run: make init
       - run: make lint
 
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.10
 
       - run: make init
 

--- a/.github/workflows/deply-to-dev.yml
+++ b/.github/workflows/deply-to-dev.yml
@@ -9,7 +9,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: 3.9
       - run: make init
       - run: make lint
 
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: 3.9
 
       - run: make init
 

--- a/.github/workflows/deply-to-dev.yml
+++ b/.github/workflows/deply-to-dev.yml
@@ -9,7 +9,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - run: make init
       - run: make lint
 
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - run: make init
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: setup
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn:python3.10 AS production
+FROM tiangolo/uvicorn-gunicorn:python3.9 AS production
 
 COPY . /src
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10 AS production
+FROM tiangolo/uvicorn-gunicorn:python3.11 AS production
 
 COPY . /src
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn:python3.11 AS production
+FROM tiangolo/uvicorn-gunicorn:python3.10 AS production
 
 COPY . /src
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8 AS production
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10 AS production
 
 COPY . /src
 WORKDIR /src

--- a/application/core/templates.py
+++ b/application/core/templates.py
@@ -2,7 +2,7 @@ import jinja2
 
 from fastapi.templating import Jinja2Templates
 
-from digital_land_frontend.globals import random_int
+import random
 
 from application.core.filters import (
     generate_query_param_str,
@@ -25,6 +25,11 @@ from application.core.filters import (
 )
 
 from application.core.utils import model_dumps
+
+
+def random_int(n=1):
+    return "".join([str(random.randint(0, 9)) for i in range(n)])
+
 
 templates = Jinja2Templates("application/templates")
 

--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -70,7 +70,6 @@ def get_entity_search(parameters: dict):
     params = normalised_params(parameters)
 
     with get_context_session() as session:
-
         query_args = [EntityOrm, func.count(EntityOrm.entity).over().label("count")]
         query = session.query(*query_args)
         query = _apply_base_filters(query, params)
@@ -90,7 +89,6 @@ def get_entity_search(parameters: dict):
 
 
 def _apply_base_filters(query, params):
-
     # exclude any params that match an entity field name but need special handling
     excluded = set(["geometry"])
 
@@ -136,7 +134,6 @@ def _apply_date_filters(query, params):
 
 
 def _apply_location_filters(session, query, params):
-
     point = get_point(params)
     if point is not None:
         query = query.filter(

--- a/application/db/models.py
+++ b/application/db/models.py
@@ -16,7 +16,6 @@ Base = declarative_base()
 
 
 class EntityOrm(Base):
-
     __tablename__ = "entity"
 
     entity = Column(BIGINT, primary_key=True, autoincrement=False)
@@ -61,7 +60,6 @@ idx_entity_typology = Index("idx_entity_typology", EntityOrm.typology)
 
 
 class OldEntityOrm(Base):
-
     __tablename__ = "old_entity"
 
     old_entity_id = Column(
@@ -89,7 +87,6 @@ class OldEntityOrm(Base):
 
 
 class DatasetOrm(Base):
-
     __tablename__ = "dataset"
 
     dataset = Column(Text, primary_key=True)
@@ -141,7 +138,6 @@ class DatasetOrm(Base):
 
     @property
     def attribution_text(self):
-
         if "[year]" in self._attribution.text:
             current_year = datetime.today().strftime("%Y")
             return self._attribution.text.replace("[year]", current_year)
@@ -150,7 +146,6 @@ class DatasetOrm(Base):
 
     @property
     def licence_text(self):
-
         if "[year]" in self._licence.text:
             current_year = datetime.today().strftime("%Y")
             return self._licence.text.replace("[year]", current_year)
@@ -159,7 +154,6 @@ class DatasetOrm(Base):
 
 
 class TypologyOrm(Base):
-
     __tablename__ = "typology"
 
     typology = Column(Text, primary_key=True)
@@ -175,7 +169,6 @@ class TypologyOrm(Base):
 
 
 class OrganisationOrm(Base):
-
     __tablename__ = "organisation"
 
     organisation = Column(Text, primary_key=True)
@@ -196,7 +189,6 @@ class OrganisationOrm(Base):
 
 
 class DatasetCollectionOrm(Base):
-
     __tablename__ = "dataset_collection"
 
     dataset_collection = Column(Text, primary_key=True)
@@ -208,7 +200,6 @@ class DatasetCollectionOrm(Base):
 
 
 class DatasetPublicationCountOrm(Base):
-
     __tablename__ = "dataset_publication"
 
     dataset_publication = Column(Text, primary_key=True)
@@ -217,7 +208,6 @@ class DatasetPublicationCountOrm(Base):
 
 
 class LookupOrm(Base):
-
     __tablename__ = "lookup"
 
     id = Column(BIGINT, primary_key=True, autoincrement=False)
@@ -231,7 +221,6 @@ class LookupOrm(Base):
 
 
 class AttributionOrm(Base):
-
     __tablename__ = "attribution"
 
     attribution = Column(Text, primary_key=True)
@@ -242,7 +231,6 @@ class AttributionOrm(Base):
 
 
 class LicenceOrm(Base):
-
     __tablename__ = "licence"
 
     licence = Column(Text, primary_key=True)

--- a/application/factory.py
+++ b/application/factory.py
@@ -118,7 +118,6 @@ def add_base_routes(app):
         "/invalid-geometries", response_class=JSONResponse, include_in_schema=False
     )
     def invalid_geometries():
-
         from application.db.session import get_context_session
         from application.core.models import entity_factory
         from sqlalchemy import func
@@ -259,7 +258,6 @@ def add_base_routes(app):
 
 
 def add_routers(app):
-
     app.include_router(entity.router, prefix="/entity")
     app.include_router(dataset.router, prefix="/dataset")
     app.include_router(curie.router, prefix="/curie")
@@ -274,7 +272,6 @@ def add_routers(app):
 
 
 def add_static(app):
-
     app.mount(
         "/static",
         StaticFiles(directory="static"),
@@ -283,7 +280,6 @@ def add_static(app):
 
 
 def add_middleware(app):
-
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/application/routers/about_.py
+++ b/application/routers/about_.py
@@ -29,7 +29,6 @@ def get_breadcrumbs(path):
     crumb_dict = [{"href": "/about/", "text": "About"}]
     # loop for the number of times there are items in the split_path list
     for i in range(total_items):
-
         # instantiate some variables
         index = i + 1
         text = split_path[-index]
@@ -69,7 +68,6 @@ def get_breadcrumbs(path):
 
 @router.get("/{url_path:path}")
 async def catch_all(request: Request, url_path: str):
-
     index_file = "index"
 
     # if URL path in this route is empty
@@ -92,7 +90,6 @@ async def catch_all(request: Request, url_path: str):
     # if template file exists use it to render the page based
     # on the corresponding URL Path
     if os.path.exists(sys_path_to_file) and os.path.isfile(sys_path_to_file):
-
         return templates.TemplateResponse(
             f"{url_path_to_file}{file_extension}",  # path to the template file we wish to render
             {

--- a/application/routers/curie.py
+++ b/application/routers/curie.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 
 def get_entity_redirect_by_curie(request: Request, prefix: str, reference: str):
-
     with get_context_session() as session:
         lookup = (
             session.query(LookupOrm.entity.label("entity"))

--- a/application/routers/dataset.py
+++ b/application/routers/dataset.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 def get_datasets_by_typology(datasets):
-
     typologies = {}
     for ds in (d for d in datasets if d.typology):
         typology = ds.typology

--- a/application/routers/entity.py
+++ b/application/routers/entity.py
@@ -79,7 +79,6 @@ def get_entity(
         else:
             return RedirectResponse(f"/entity/{new_entity_id}", status_code=301)
     elif e is not None:
-
         if extension is not None and extension.value == "json":
             return e.dict(by_alias=True, exclude={"geojson"})
 
@@ -167,7 +166,6 @@ def search_entities(
     links = make_links(scheme, netloc, path, query, data)
 
     if extension is not None and extension.value == "json":
-
         if params.get("field") is not None:
             include = set([to_snake(field) for field in params.get("field")])
             entities = _get_entity_json(data["entities"], include=include)

--- a/application/routers/fact.py
+++ b/application/routers/fact.py
@@ -53,13 +53,11 @@ def get_fact(
     query_filters: FactDatasetQueryFilters = Depends(),
     extension: Optional[SuffixEntity] = None,
 ):
-
     query_params = asdict(query_filters)
     path_params = asdict(path_params)
     fact = get_fact_query(path_params["fact"], query_params["dataset"])
 
     if fact is not None:
-
         if extension is not None and extension.value == "json":
             return fact.dict(by_alias=True, exclude={"geojson"})
 
@@ -105,7 +103,6 @@ def search_facts(
     facts = get_search_facts_query(query_params)
 
     if facts is not None:
-
         if extension is not None and extension.value == "json":
             return facts
 

--- a/application/routers/guidance_.py
+++ b/application/routers/guidance_.py
@@ -29,7 +29,6 @@ def get_breadcrumbs(path):
     crumb_dict = [{"href": "/guidance/", "text": "Guidance"}]
     # loop for the number of times there are items in the split_path list
     for i in range(total_items):
-
         # instantiate some variables
         index = i + 1
         text = split_path[-index]
@@ -69,7 +68,6 @@ def get_breadcrumbs(path):
 
 @router.get("/{url_path:path}")
 async def catch_all(request: Request, url_path: str):
-
     index_file = "index"
 
     # if URL path in this route is empty
@@ -94,7 +92,6 @@ async def catch_all(request: Request, url_path: str):
     # if template file exists use it to render the page based
     # on the corresponding URL Path
     if os.path.exists(sys_path_to_file) and os.path.isfile(sys_path_to_file):
-
         return templates.TemplateResponse(
             f"{url_path_to_file}{file_extension}",  # path to the template file we wish to render
             {

--- a/application/search/filters.py
+++ b/application/search/filters.py
@@ -41,7 +41,6 @@ class DatasetQueryFilters:
 
 @dataclass
 class QueryFilters:
-
     # base filters
     theme: Optional[List[str]] = Query(None, include_in_schema=False)
     typology: Optional[List[str]] = Query(

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -9,3 +9,4 @@ pytest-pudb
 SQLAlchemy-Utils
 pytest-mock
 pytest-md-report
+pre-commit

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -11,7 +11,9 @@ certifi==2023.5.7
     #   -c requirements/requirements.txt
     #   requests
 cfgv==3.3.1
-    # via pre-commit
+    # via
+    #   -c requirements/requirements.txt
+    #   pre-commit
 chardet==5.1.0
     # via mbstrdecoder
 charset-normalizer==3.2.0
@@ -27,13 +29,17 @@ dataproperty==1.0.0
     #   pytablewriter
     #   tabledata
 distlib==0.3.6
-    # via virtualenv
+    # via
+    #   -c requirements/requirements.txt
+    #   virtualenv
 exceptiongroup==1.1.2
     # via
     #   -c requirements/requirements.txt
     #   pytest
 filelock==3.12.2
-    # via virtualenv
+    # via
+    #   -c requirements/requirements.txt
+    #   virtualenv
 flake8==6.0.0
     # via -r requirements/dev-requirements.in
 greenlet==2.0.2
@@ -42,7 +48,9 @@ greenlet==2.0.2
     #   playwright
     #   sqlalchemy
 identify==2.5.24
-    # via pre-commit
+    # via
+    #   -c requirements/requirements.txt
+    #   pre-commit
 idna==3.4
     # via
     #   -c requirements/requirements.txt
@@ -61,7 +69,9 @@ mccabe==0.7.0
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.8.0
-    # via pre-commit
+    # via
+    #   -c requirements/requirements.txt
+    #   pre-commit
 packaging==23.1
     # via
     #   -c requirements/requirements.txt
@@ -75,8 +85,9 @@ pathspec==0.11.1
     # via black
 pathvalidate==3.0.0
     # via pytablewriter
-platformdirs==3.8.1
+platformdirs==3.9.1
     # via
+    #   -c requirements/requirements.txt
     #   black
     #   virtualenv
 playwright==1.35.0
@@ -86,7 +97,9 @@ playwright==1.35.0
 pluggy==1.2.0
     # via pytest
 pre-commit==3.3.3
-    # via -r requirements/dev-requirements.in
+    # via
+    #   -c requirements/requirements.txt
+    #   -r requirements/dev-requirements.in
 pudb==2022.1.3
     # via pytest-pudb
 pycodestyle==2.10.0
@@ -175,8 +188,10 @@ urwid==2.1.2
     #   urwid-readline
 urwid-readline==0.13
     # via pudb
-virtualenv==20.23.1
-    # via pre-commit
+virtualenv==20.24.0
+    # via
+    #   -c requirements/requirements.txt
+    #   pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -4,79 +4,78 @@
 #
 #    pip-compile requirements/dev-requirements.in
 #
-attrs==21.4.0
-    # via
-    #   -c requirements/requirements.txt
-    #   pytest
-backports-entry-points-selectable==1.1.1
-    # via virtualenv
-black==22.3.0
+black==23.7.0
     # via -r requirements/dev-requirements.in
-certifi==2021.10.8
+certifi==2023.5.7
     # via
     #   -c requirements/requirements.txt
     #   requests
 cfgv==3.3.1
     # via pre-commit
-chardet==5.0.0
+chardet==5.1.0
     # via mbstrdecoder
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
     #   -c requirements/requirements.txt
     #   requests
-click==8.1.3
+click==8.1.5
     # via
     #   -c requirements/requirements.txt
     #   black
-dataproperty==0.55.0
+dataproperty==1.0.0
     # via
     #   pytablewriter
     #   tabledata
-distlib==0.3.4
+distlib==0.3.6
     # via virtualenv
-filelock==3.4.0
+exceptiongroup==1.1.2
+    # via
+    #   -c requirements/requirements.txt
+    #   pytest
+filelock==3.12.2
     # via virtualenv
-flake8==4.0.1
+flake8==6.0.0
     # via -r requirements/dev-requirements.in
 greenlet==2.0.2
     # via
     #   -c requirements/requirements.txt
     #   playwright
     #   sqlalchemy
-identify==2.4.0
+identify==2.5.24
     # via pre-commit
-idna==3.3
+idna==3.4
     # via
     #   -c requirements/requirements.txt
     #   requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-jedi==0.18.1
+jedi==0.18.2
     # via pudb
-mbstrdecoder==1.1.1
+mbstrdecoder==1.1.3
     # via
     #   dataproperty
     #   pytablewriter
     #   typepy
-mccabe==0.6.1
+mccabe==0.7.0
     # via flake8
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
-nodeenv==1.6.0
+nodeenv==1.8.0
     # via pre-commit
-packaging==21.3
+packaging==23.1
     # via
     #   -c requirements/requirements.txt
+    #   black
     #   pudb
     #   pytest
     #   typepy
 parso==0.8.3
     # via jedi
-pathspec==0.9.0
+pathspec==0.11.1
     # via black
-pathvalidate==2.5.2
+pathvalidate==3.0.0
     # via pytablewriter
-platformdirs==2.4.0
+platformdirs==3.8.1
     # via
     #   black
     #   virtualenv
@@ -84,29 +83,23 @@ playwright==1.35.0
     # via
     #   -r requirements/dev-requirements.in
     #   pytest-playwright
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
-pre-commit==2.16.0
+pre-commit==3.3.3
     # via -r requirements/dev-requirements.in
-pudb==2022.1.1
+pudb==2022.1.3
     # via pytest-pudb
-py==1.11.0
-    # via pytest
-pycodestyle==2.8.0
+pycodestyle==2.10.0
     # via flake8
 pyee==9.0.4
     # via playwright
-pyflakes==2.4.0
+pyflakes==3.0.1
     # via flake8
-pygments==2.11.2
+pygments==2.15.1
     # via pudb
-pyparsing==3.0.8
-    # via
-    #   -c requirements/requirements.txt
-    #   packaging
-pytablewriter==0.64.2
+pytablewriter==1.0.0
     # via pytest-md-report
-pytest==6.2.5
+pytest==7.4.0
     # via
     #   -r requirements/dev-requirements.in
     #   pytest-base-url
@@ -114,46 +107,43 @@ pytest==6.2.5
     #   pytest-mock
     #   pytest-playwright
     #   pytest-pudb
-pytest-base-url==1.4.2
+pytest-base-url==2.0.0
     # via pytest-playwright
-pytest-md-report==0.3.0
+pytest-md-report==0.3.2
     # via -r requirements/dev-requirements.in
-pytest-mock==3.8.2
+pytest-mock==3.11.1
     # via -r requirements/dev-requirements.in
-pytest-playwright==0.2.2
+pytest-playwright==0.3.3
     # via -r requirements/dev-requirements.in
 pytest-pudb==0.7.0
     # via -r requirements/dev-requirements.in
 python-dateutil==2.8.2
     # via typepy
-python-slugify==6.1.2
+python-slugify==8.0.1
     # via
     #   -c requirements/requirements.txt
     #   pytest-playwright
-pytz==2022.6
+pytz==2023.3
     # via typepy
 pyyaml==6.0
     # via
     #   -c requirements/requirements.txt
     #   pre-commit
-requests==2.27.1
+requests==2.31.0
     # via
     #   -c requirements/requirements.txt
     #   pytest-base-url
 six==1.16.0
-    # via
-    #   python-dateutil
-    #   sqlalchemy-utils
-    #   virtualenv
-sqlalchemy==1.4.36
+    # via python-dateutil
+sqlalchemy==1.4.49
     # via
     #   -c requirements/requirements.txt
     #   sqlalchemy-utils
-sqlalchemy-utils==0.38.2
+sqlalchemy-utils==0.41.1
     # via -r requirements/dev-requirements.in
-tabledata==1.3.0
+tabledata==1.3.1
     # via pytablewriter
-tcolorpy==0.1.2
+tcolorpy==0.1.3
     # via
     #   pytablewriter
     #   pytest-md-report
@@ -161,19 +151,21 @@ text-unidecode==1.3
     # via
     #   -c requirements/requirements.txt
     #   python-slugify
-toml==0.10.2
+tomli==2.0.1
     # via
-    #   pre-commit
+    #   black
     #   pytest
-tomli==1.2.3
-    # via black
-typepy[datetime]==1.3.0
+typepy[datetime]==1.3.1
     # via
     #   dataproperty
     #   pytablewriter
     #   pytest-md-report
     #   tabledata
-urllib3==1.26.9
+typing-extensions==4.7.1
+    # via
+    #   -c requirements/requirements.txt
+    #   pyee
+urllib3==2.0.3
     # via
     #   -c requirements/requirements.txt
     #   requests
@@ -183,10 +175,8 @@ urwid==2.1.2
     #   urwid-readline
 urwid-readline==0.13
     # via pudb
-virtualenv==20.10.0
+virtualenv==20.23.1
     # via pre-commit
-websockets==10.1
-    # via playwright
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,10 +1,7 @@
-gitpython
 fastapi==0.75.2
-aiofiles
 uvicorn
 gunicorn
 jinja2
-aiohttp[speedups]
 PyYAML
 python-dotenv
 requests
@@ -22,3 +19,4 @@ beautifulsoup4
 python-slugify
 govuk-frontend-jinja
 validators
+pre-commit

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,5 @@
 gitpython
-fastapi
+fastapi==0.75.2
 aiofiles
 uvicorn
 gunicorn
@@ -20,3 +20,5 @@ jsonpickle
 uritemplate
 beautifulsoup4
 python-slugify
+govuk-frontend-jinja
+validators

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,40 +4,26 @@
 #
 #    pip-compile --output-file=requirements/requirements.txt requirements/requirements.in
 #
-aiodns==3.0.0
-    # via aiohttp
-aiofiles==23.1.0
-    # via -r requirements/requirements.in
-aiohttp[speedups]==3.8.4
-    # via -r requirements/requirements.in
-aiosignal==1.3.1
-    # via aiohttp
 alembic==1.11.1
     # via -r requirements/requirements.in
 anyio==3.7.1
     # via starlette
-async-timeout==4.0.2
-    # via aiohttp
-attrs==23.1.0
-    # via aiohttp
 beautifulsoup4==4.12.2
     # via -r requirements/requirements.in
-brotli==1.0.9
-    # via aiohttp
 certifi==2023.5.7
     # via
     #   requests
     #   sentry-sdk
-cffi==1.15.1
-    # via pycares
+cfgv==3.3.1
+    # via pre-commit
 charset-normalizer==3.2.0
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 click==8.1.5
     # via uvicorn
 decorator==5.1.1
     # via validators
+distlib==0.3.6
+    # via virtualenv
 exceptiongroup==1.1.2
     # via anyio
 fastapi==0.75.2
@@ -46,15 +32,9 @@ fastapi==0.75.2
     #   fastapi-utils
 fastapi-utils==0.2.1
     # via -r requirements/requirements.in
-frozenlist==1.4.0
-    # via
-    #   aiohttp
-    #   aiosignal
+filelock==3.12.2
+    # via virtualenv
 geoalchemy2==0.14.0
-    # via -r requirements/requirements.in
-gitdb==4.0.10
-    # via gitpython
-gitpython==3.1.32
     # via -r requirements/requirements.in
 govuk-frontend-jinja==2.7.0
     # via -r requirements/requirements.in
@@ -64,11 +44,12 @@ gunicorn==20.1.0
     # via -r requirements/requirements.in
 h11==0.14.0
     # via uvicorn
+identify==2.5.24
+    # via pre-commit
 idna==3.4
     # via
     #   anyio
     #   requests
-    #   yarl
 jinja2==3.1.2
     # via
     #   -r requirements/requirements.in
@@ -83,20 +64,18 @@ markupsafe==2.1.3
     # via
     #   jinja2
     #   mako
-multidict==6.0.4
-    # via
-    #   aiohttp
-    #   yarl
+nodeenv==1.8.0
+    # via pre-commit
 numpy==1.25.1
     # via shapely
 packaging==23.1
     # via geoalchemy2
+platformdirs==3.9.1
+    # via virtualenv
+pre-commit==3.3.3
+    # via -r requirements/requirements.in
 psycopg2==2.9.6
     # via -r requirements/requirements.in
-pycares==4.3.0
-    # via aiodns
-pycparser==2.21
-    # via cffi
 pydantic==1.10.11
     # via
     #   fastapi
@@ -106,15 +85,15 @@ python-dotenv==1.0.0
 python-slugify==8.0.1
     # via -r requirements/requirements.in
 pyyaml==6.0
-    # via -r requirements/requirements.in
+    # via
+    #   -r requirements/requirements.in
+    #   pre-commit
 requests==2.31.0
     # via -r requirements/requirements.in
 sentry-sdk==1.28.1
     # via -r requirements/requirements.in
 shapely==2.0.1
     # via -r requirements/requirements.in
-smmap==5.0.0
-    # via gitdb
 sniffio==1.3.0
     # via anyio
 soupsieve==2.4.1
@@ -125,14 +104,13 @@ sqlalchemy==1.4.49
     #   alembic
     #   fastapi-utils
     #   geoalchemy2
-starlette==0.27.0
+starlette==0.17.1
     # via fastapi
 text-unidecode==1.3
     # via python-slugify
 typing-extensions==4.7.1
     # via
     #   alembic
-    #   fastapi
     #   pydantic
 uritemplate==4.1.1
     # via -r requirements/requirements.in
@@ -144,8 +122,8 @@ uvicorn==0.22.0
     # via -r requirements/requirements.in
 validators==0.20.0
     # via -r requirements/requirements.in
-yarl==1.9.2
-    # via aiohttp
+virtualenv==20.24.0
+    # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,69 +6,65 @@
 #
 aiodns==3.0.0
     # via aiohttp
-aiofiles==0.8.0
+aiofiles==23.1.0
     # via -r requirements/requirements.in
-aiohttp[speedups]==3.8.1
+aiohttp[speedups]==3.8.4
     # via -r requirements/requirements.in
-aiosignal==1.2.0
+aiosignal==1.3.1
     # via aiohttp
-alembic==1.7.7
+alembic==1.11.1
     # via -r requirements/requirements.in
-anyio==3.5.0
+anyio==3.7.1
     # via starlette
-asgiref==3.5.0
-    # via uvicorn
 async-timeout==4.0.2
     # via aiohttp
-attrs==21.4.0
+attrs==23.1.0
     # via aiohttp
-beautifulsoup4==4.11.1
+beautifulsoup4==4.12.2
     # via -r requirements/requirements.in
 brotli==1.0.9
     # via aiohttp
-cchardet==2.1.7
-    # via aiohttp
-certifi==2021.10.8
+certifi==2023.5.7
     # via
     #   requests
     #   sentry-sdk
-cffi==1.15.0
+cffi==1.15.1
     # via pycares
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
-click==8.1.3
+click==8.1.5
     # via uvicorn
 decorator==5.1.1
     # via validators
-digital_land_frontend @ git+https://github.com/digital-land/digital-land-frontend.git
-    # via -r requirements/requirements.in
+exceptiongroup==1.1.2
+    # via anyio
 fastapi==0.75.2
     # via
     #   -r requirements/requirements.in
     #   fastapi-utils
 fastapi-utils==0.2.1
     # via -r requirements/requirements.in
-frozenlist==1.3.0
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-geoalchemy2==0.11.1
+geoalchemy2==0.14.0
     # via -r requirements/requirements.in
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.31
+gitpython==3.1.32
     # via -r requirements/requirements.in
-govuk-frontend-jinja==2.6.0
-    # via digital-land-frontend
+govuk-frontend-jinja==2.7.0
+    # via -r requirements/requirements.in
 greenlet==2.0.2
     # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements/requirements.in
-h11==0.13.0
+h11==0.14.0
     # via uvicorn
-idna==3.3
+idna==3.4
     # via
     #   anyio
     #   requests
@@ -77,75 +73,78 @@ jinja2==3.1.2
     # via
     #   -r requirements/requirements.in
     #   govuk-frontend-jinja
-jsonpickle==2.2.0
+jsonpickle==3.0.1
     # via -r requirements/requirements.in
-mako==1.2.0
+mako==1.2.4
     # via alembic
-markdown==3.3.6
+markdown==3.4.3
     # via -r requirements/requirements.in
-markupsafe==2.1.1
+markupsafe==2.1.3
     # via
     #   jinja2
     #   mako
-multidict==6.0.2
+multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-packaging==21.3
+numpy==1.25.1
+    # via shapely
+packaging==23.1
     # via geoalchemy2
-psycopg2==2.9.3
+psycopg2==2.9.6
     # via -r requirements/requirements.in
-pycares==4.1.2
+pycares==4.3.0
     # via aiodns
 pycparser==2.21
     # via cffi
-pydantic==1.9.0
+pydantic==1.10.11
     # via
     #   fastapi
     #   fastapi-utils
-pyparsing==3.0.8
-    # via packaging
-python-dotenv==0.20.0
+python-dotenv==1.0.0
     # via -r requirements/requirements.in
-python-slugify==6.1.2
+python-slugify==8.0.1
     # via -r requirements/requirements.in
 pyyaml==6.0
     # via -r requirements/requirements.in
-requests==2.27.1
+requests==2.31.0
     # via -r requirements/requirements.in
-sentry-sdk==1.6.0
+sentry-sdk==1.28.1
     # via -r requirements/requirements.in
-shapely==1.8.1.post1
+shapely==2.0.1
     # via -r requirements/requirements.in
 smmap==5.0.0
     # via gitdb
-sniffio==1.2.0
+sniffio==1.3.0
     # via anyio
-soupsieve==2.3.2.post1
+soupsieve==2.4.1
     # via beautifulsoup4
-sqlalchemy==1.4.36
+sqlalchemy==1.4.49
     # via
     #   -r requirements/requirements.in
     #   alembic
     #   fastapi-utils
     #   geoalchemy2
-starlette==0.17.1
+starlette==0.27.0
     # via fastapi
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.2.0
-    # via pydantic
+typing-extensions==4.7.1
+    # via
+    #   alembic
+    #   fastapi
+    #   pydantic
 uritemplate==4.1.1
     # via -r requirements/requirements.in
-urllib3==1.26.9
+urllib3==2.0.3
     # via
     #   requests
     #   sentry-sdk
-uvicorn==0.17.6
+uvicorn==0.22.0
     # via -r requirements/requirements.in
 validators==0.20.0
-    # via digital-land-frontend
-yarl==1.7.2
+    # via -r requirements/requirements.in
+yarl==1.9.2
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tests/acceptance/test_acceptance.py
+++ b/tests/acceptance/test_acceptance.py
@@ -41,7 +41,6 @@ def server_process():
 
 
 def test_acceptance(server_process, page, test_data):
-
     page.goto(BASE_URL)
 
     page.click("text=Datasets")

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -9,7 +9,6 @@ from tests.test_data.wkt_data import (
 
 
 def _transform_dataset_fixture_to_response(datasets, is_geojson=False):
-
     for dataset in datasets:
         _transform_dataset_to_response(dataset)
     return datasets
@@ -36,7 +35,6 @@ def _transform_dataset_to_response(dataset, is_geojson=False):
 
 
 def test_app_returns_valid_geojson_list(client):
-
     response = client.get("/entity.geojson", headers={"Origin": "localhost"})
     data = response.json()
     assert "type" in data
@@ -131,7 +129,6 @@ def test_old_entity_gone_shown(test_data_old_entities, client, exclude_middlewar
 
 
 def test_dataset_json_endpoint_returns_as_expected(client, test_data):
-
     from tests.test_data import datasets
 
     response = client.get("/dataset.json")
@@ -168,7 +165,6 @@ wkt_params = [
 
 @pytest.mark.parametrize("point, expected_status_code", wkt_params)
 def test_api_handles_invalid_wkt(point, expected_status_code, client, test_data):
-
     params = {"geometry_relation": "intersects", "geometry": point}
     response = client.get("/entity.geojson", params=params)
     assert response.status_code == expected_status_code

--- a/tests/integration/test_entity_search.py
+++ b/tests/integration/test_entity_search.py
@@ -112,7 +112,6 @@ def test_search_entity_by_dataset_names_not_in_system_returns_only_missing(
 
 
 def test_search_entity_by_single_dataset_name(test_data, params):
-
     params["dataset"] = ["greenspace"]
     result = get_entity_search(params)
     assert 1 == result["count"]
@@ -122,7 +121,6 @@ def test_search_entity_by_single_dataset_name(test_data, params):
 
 
 def test_search_entity_by_list_of_dataset_names(test_data, params):
-
     params["dataset"] = ["greenspace", "brownfield-site"]
     result = get_entity_search(params)
     assert 2 == result["count"]
@@ -132,7 +130,6 @@ def test_search_entity_by_list_of_dataset_names(test_data, params):
 
 
 def test_search_entity_by_date_since(test_data, params):
-
     params["entry_date_year"] = 2019
     params["entry_date_month"] = 1
     params["entry_date_day"] = 1
@@ -195,7 +192,6 @@ def test_search_entity_by_date_since(test_data, params):
 
 
 def test_search_entity_by_date_before(test_data, params):
-
     params["entry_date_year"] = 2019
     params["entry_date_month"] = 1
     params["entry_date_day"] = 1
@@ -232,7 +228,6 @@ def test_search_entity_by_date_before(test_data, params):
 
 
 def test_search_entity_by_date_equal(test_data, params):
-
     params["entry_date_year"] = 2019
     params["entry_date_month"] = 1
     params["entry_date_day"] = 1
@@ -249,7 +244,6 @@ def test_search_entity_by_date_equal(test_data, params):
 
 
 def test_search_entity_by_point(test_data, params):
-
     params["longitude"] = -1.64794921875
     params["latitude"] = 50.51342652633956
 
@@ -266,7 +260,6 @@ def test_search_entity_by_point(test_data, params):
 
 
 def test_search_entity_by_single_polygon_intersects(test_data, params):
-
     from tests.test_data.wkt_data import intersects_with_brownfield_entity as brownfield
     from tests.test_data.wkt_data import intersects_with_greenspace_entity as greenspace
 
@@ -286,7 +279,6 @@ def test_search_entity_by_single_polygon_intersects(test_data, params):
 
 
 def test_search_entity_by_list_of_polygons_that_intersect(test_data, params):
-
     from tests.test_data.wkt_data import intersects_with_brownfield_entity as brownfield
     from tests.test_data.wkt_data import intersects_with_greenspace_entity as greenspace
 
@@ -298,7 +290,6 @@ def test_search_entity_by_list_of_polygons_that_intersect(test_data, params):
 
 
 def test_search_entity_by_polygon_with_no_intersection(test_data, params):
-
     from tests.test_data.wkt_data import no_intersection
 
     params["geometry"] = [no_intersection]
@@ -309,7 +300,6 @@ def test_search_entity_by_polygon_with_no_intersection(test_data, params):
 
 
 def test_search_all_entities(test_data, params):
-
     # default is EntriesOption.all - already in params
     result = get_entity_search(params)
     assert result["count"] == NUMBER_OF_ENTITIES_IN_TEST_FIXTURE
@@ -326,7 +316,6 @@ def test_search_all_entities(test_data, params):
 
 
 def test_search_current_entries(test_data, params):
-
     # entries without an end date
     params["entries"] = EntriesOption.current
 
@@ -344,7 +333,6 @@ def test_search_current_entries(test_data, params):
 
 
 def test_search_historical_entries(test_data, params):
-
     # entries with an end date
     params["entries"] = EntriesOption.historical
 
@@ -402,7 +390,6 @@ def test_search_filtering_does_affect_count(test_data, client, exclude_middlewar
 
 
 def test_search_entity_equal_to_a_polygon(test_data, params):
-
     from tests.test_data.wkt_data import equals_brownfield_site_entity
 
     params["geometry"] = [equals_brownfield_site_entity]
@@ -414,7 +401,6 @@ def test_search_entity_equal_to_a_polygon(test_data, params):
 
 
 def test_search_entity_disjoint_from_a_polygon(test_data, params):
-
     from tests.test_data.wkt_data import no_intersection
 
     params["geometry"] = [no_intersection]
@@ -425,7 +411,6 @@ def test_search_entity_disjoint_from_a_polygon(test_data, params):
 
 
 def test_search_entity_that_polygon_touches(test_data, params):
-
     from tests.test_data.wkt_data import touches_forest_entity
 
     params["geometry"] = [touches_forest_entity]
@@ -437,7 +422,6 @@ def test_search_entity_that_polygon_touches(test_data, params):
 
 
 def test_search_entity_that_contains_a_polygon(test_data, params):
-
     from tests.test_data.wkt_data import contained_by_greenspace_entity
 
     params["geometry"] = [contained_by_greenspace_entity]
@@ -450,7 +434,6 @@ def test_search_entity_that_contains_a_polygon(test_data, params):
 
 # when dealing with polygons contains and covers are synonymous
 def test_search_entity_that_covers_a_polygon(test_data, params):
-
     from tests.test_data.wkt_data import contained_by_greenspace_entity
 
     params["geometry"] = [contained_by_greenspace_entity]
@@ -462,7 +445,6 @@ def test_search_entity_that_covers_a_polygon(test_data, params):
 
 
 def test_search_entity_covered_by_a_polygon(test_data, params):
-
     from tests.test_data.wkt_data import covers_historical_monument_entity
 
     params["geometry"] = [covers_historical_monument_entity]
@@ -474,7 +456,6 @@ def test_search_entity_covered_by_a_polygon(test_data, params):
 
 
 def test_search_entity_that_overlaps_a_polygon(test_data, params):
-
     from tests.test_data.wkt_data import intersects_with_brownfield_entity
 
     params["geometry"] = [intersects_with_brownfield_entity]
@@ -486,7 +467,6 @@ def test_search_entity_that_overlaps_a_polygon(test_data, params):
 
 
 def test_search_entity_that_is_crossed_by_a_line(test_data, params):
-
     from tests.test_data.wkt_data import crosses_historical_entity
 
     params["geometry"] = [crosses_historical_entity]
@@ -500,7 +480,6 @@ def test_search_entity_that_is_crossed_by_a_line(test_data, params):
 def test_search_geometry_entity_returns_entities_that_intersect_with_entity(
     test_data, params
 ):
-
     test_conservation_area = [
         e for e in test_data["entities"] if e["dataset"] == "conservation-area"
     ][0]
@@ -518,7 +497,6 @@ def test_search_geometry_entity_returns_entities_that_intersect_with_entity(
 
 
 def test_search_entity_by_curie(test_data, params):
-
     expected_entity = [
         e
         for e in test_data["entities"]
@@ -539,7 +517,6 @@ def test_search_entity_by_curie(test_data, params):
 
 
 def test_search_entity_by_organisation_curie(test_data, params):
-
     expected_entity = [
         e
         for e in test_data["entities"]

--- a/tests/integration/test_search_invalid_entities.py
+++ b/tests/integration/test_search_invalid_entities.py
@@ -69,7 +69,6 @@ def params(raw_params):
 
 
 def test_search_geometry_reference_excludes_invalid_data(invalid_test_data, params):
-
     invalid = [
         int(entity["entity"])
         for entity in invalid_test_data["entities"]
@@ -90,7 +89,6 @@ def test_search_geometry_reference_excludes_invalid_data(invalid_test_data, para
 def test_search_by_dataset_and_lasso_excludes_invalid_geometry(
     invalid_test_data, params
 ):
-
     params["dataset"] = ["world-heritage-site"]
     params["geometry_relation"] = GeometryRelation.intersects.name
     params["geometry"] = [handrians_wall_search]

--- a/tests/unit/search/test_validators.py
+++ b/tests/unit/search/test_validators.py
@@ -144,7 +144,6 @@ invalid_curies = [
 
 @pytest.mark.parametrize("curie", invalid_curies)
 def test_validate_invalid_curie(curie):
-
     with pytest.raises(DigitalLandValidationError):
         validate_curies([curie])
 

--- a/tests/unit/test_pagination.py
+++ b/tests/unit/test_pagination.py
@@ -25,7 +25,6 @@ def test_pagination_links_should_be_empty_if_count_results_less_than_limit():
 
 
 def test_pagination_links_should_have_all_links_except_previous_on_first_page():
-
     data = {"count": 11, "params": {"limit": 10}}
     params = {}
     links = make_links(scheme, netloc, path, params, data)
@@ -46,7 +45,6 @@ def test_pagination_links_should_have_all_links_except_previous_on_first_page():
 
 
 def test_pagination_links_should_have_previous_link_if_not_on_last_page():
-
     data = {"count": 45, "params": {"limit": 10, "offset": 10}}
     params = {}
     links = make_links(scheme, netloc, path, params, data)


### PR DESCRIPTION
Ticket: (https://trello.com/c/VVq7jid3/297-fix-pip-requirement-for-pdguk)[https://trello.com/c/VVq7jid3/297-fix-pip-requirement-for-pdguk]

after clearing all my installed pip packages and rerunning [p.d.g.uk](http://p.d.g.uk/) it turns out that some requirements are missing, this PR adds required packages to the requirements.in file. it also specifies a version of fast api. as the latest version of fastapi isn't compatible with our code.

also, I have removed the import of dl-frontend.globals.random. and instead just included this function directly

After first putting this PR up, the tests and linting was failing due to numpy 1.25.1 being unsupported with python 3.8. 

also, some linting work was done so the linting checks pass