### PR TITLE
Test/find an entity via the search page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ test-acceptance:
 	python -m playwright install chromium
 	python -m pytest --md-report --md-report-color=never -p no:warnings tests/acceptance
 
+test-acceptance-show:
+	python -m playwright install chromium
+	python3 -m pytest --browser webkit --headed --slowmo 500 --pdb
+
 test: test-unit test-integration
 
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ test-acceptance:
 	python -m playwright install chromium
 	python -m pytest --md-report --md-report-color=never -p no:warnings tests/acceptance
 
-test-acceptance-show:
+test-acceptance-debug:
 	python -m playwright install chromium
-	python3 -m pytest --browser webkit --headed --slowmo 500 --pdb
+	PWDEBUG=1 python3 -m pytest --md-report --md-report-color=never -p no:warnings tests/acceptance
 
 test: test-unit test-integration
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Run the following command to load data into the database used by docker compose:
 make load-db
 ```
 
-Note that you will have to be authenticated with AWS ECR in order to pull the` ``digital-land-postgres` image. If you are following the [AWS Authentication](#aws-authentication) instructions from below, it would be better to run:
+Note that you will have to be authenticated with AWS ECR in order to pull the `digital-land-postgres` image. If you are following the [AWS Authentication](#aws-authentication) instructions from below, it would be better to run:
 
 ```
 aws-vault exec dl-dev -- make load-db
@@ -92,8 +92,20 @@ If you want to see the acceptance tests in action run the following:
     playwright install chromium
     python -m pytest tests/acceptance  --headed --slowmo 1000
 
+(--headed opens browser and --slowmo slows down interactions by the specified number of milliseconds)
 
---headed opens browser and --slowmo slows down interactions by the specified number of milliseconds
+If you want to step through the acceptance tests line by line using playwrights inspector, you can call
+
+    make test-acceptance-debug
+
+Note: if you are using WSL, playwright inspector wont work by default. you will need to disable gpu support in you `%UserProfile%/.wslconfig` file by adding the following lines:
+
+    gpuSupport=false
+
+(you may need to create the file if it doesn't exist)
+
+
+
 
 ### Run the application
 

--- a/tests/acceptance/test_entity.py
+++ b/tests/acceptance/test_entity.py
@@ -46,6 +46,43 @@ def test_correctly_loads_the_entity_root(server_process, page):
     assert mapControls.count() > 1
 
 
+def test_find_an_entity_via_the_search_page(server_process, page):
+    # Home page
+    breakpoint()
+    page.goto(BASE_URL)
+    page.click("text=Search")
+
+    page.wait_for_selector(
+        '//h1[contains(text(), "Search for planning and housing data")]'
+    )
+
+    resultsCountText = page.locator(
+        "//h2[contains(@class, 'app-results-summary__title')]"
+    ).first.text_content()
+    numberOfResults = int("".join(filter(str.isdigit, resultsCountText)))
+    assert numberOfResults > 0
+
+    time.sleep(5)
+
+    # Search page
+    page.locator('//label[contains(text(), "Address")]/preceding-sibling::input').click(
+        timeout=60000
+    )
+    # page.click('//label[normalize-space(text())="Ancient woodland"]/following-sibling::input[@type="textbox"]')
+    page.click("button:has-text('Search')")
+
+    with page.expect_response("**/entity/**") as response:
+        page.click("button:has-text('Search')")
+
+    assert response.value.ok
+
+    resultsCountText = page.locator(
+        "//h2[contains(@class, 'app-results-summary__title')]"
+    ).first()
+
+    print(resultsCountText.text())
+
+
 # This test is currently failing on the pipeline due to line 51 timing out
 # ========================================================================
 # def test_correctly_loads_an_entity_page(server_process, page):

--- a/tests/acceptance/test_entity.py
+++ b/tests/acceptance/test_entity.py
@@ -47,7 +47,6 @@ def test_correctly_loads_the_entity_root(server_process, page):
 
 
 def test_find_an_entity_via_the_search_page(server_process, page):
-
     page.goto(BASE_URL)
     page.get_by_role("link", name="Search", exact=True).click()
 


### PR DESCRIPTION
[https://trello.com/c/pjZnK1pD/265-write-acceptance-test-for-find-an-entity-via-the-search-page](https://trello.com/c/pjZnK1pD/265-write-acceptance-test-for-find-an-entity-via-the-search-page)

Adds a test for finding an entity via the search page

This should really use generated mock data, but the ability to generate mock data doesn't currently exist. I will look into doing that as part of another ticket then come back to this and update it to use mock data, as well as add further tests