### PR TITLE
took separators out of accessibility dom

### DIFF
--- a/application/templates/pages/about/about.md
+++ b/application/templates/pages/about/about.md
@@ -21,7 +21,7 @@ You can tell us if something doesn't look right by emailing [digitalland@levelli
 
 We are currently working with a set of LPAs to collect data according to our draft standards, that will be collected by the platform. The number of LPAs and datasets covered is growing all the time. You can find out how the platform is due to develop in our [roadmap](/about/roadmap). 
 
-<hr class="govuk-section-break govuk-section-break--m">
+<hr class="govuk-section-break govuk-section-break--m" role='presentation'>
 
 LPAs 
 ---
@@ -41,7 +41,7 @@ We are currently supporting a set of LPAs to develop our data standards and get 
 -   Newcastle City Council 
 -   Southwark 
 
-<hr class="govuk-section-break govuk-section-break--m">
+<hr class="govuk-section-break govuk-section-break--m" role='presentation'>
 
 Data collections 
 ---
@@ -62,7 +62,7 @@ For example, we need all LPAs to enter dates in the same way, so our platform kn
 
 We want to minimise the work LPAs will need to do to contribute their data. We have created guidance on how to meet the standards, and will continue to revise this through user testing. 
 
-<hr class="govuk-section-break govuk-section-break--m">
+<hr class="govuk-section-break govuk-section-break--m" role='presentation'>
 
 How the data will be used
 ---
@@ -76,7 +76,7 @@ There are 2 public services already in development that are making use of this d
 
 Services like RIPA and BOPS have the potential to save LPAs millions each year, as well as improving the planning process for homeowners and developers. 
 
-<hr class="govuk-section-break govuk-section-break--m">
+<hr class="govuk-section-break govuk-section-break--m" role='presentation'>
 
 UK PropTech
 ---
@@ -89,4 +89,4 @@ We are keen to hear from and potentially highlight external users of this data, 
 
 A number of companies already provide access to public sector planning data. If you are looking for commercial services providing national data coverage, access to historic data, or insights and services, have a look at companies such as [LandTech](https://land.tech/), [Glenigan](https://www.glenigan.com/), [Nimbus](https://www.nimbusmaps.co.uk/), [Urban Intelligence](https://urbanintelligence.co.uk/) and [Realyse](https://www.realyse.com/) among others.
 
-<hr class="govuk-section-break govuk-section-break--m">
+<hr class="govuk-section-break govuk-section-break--m" role='presentation'>


### PR DESCRIPTION
Ticket: https://trello.com/c/ycMjt4t9/392-improve-the-accessibility-of-the-about-page-and-roadmap-page

Accessibility Checks: 

1. Ensure there is a hidden link at the top of the page that is the first tabbable element, that is a skip to main content link: Yes
2. Ensure you can tab forward through all clickable sections
3. Making sure all links are correctly highlighted when tabbed to: Yes
4. Make sure links exist to skip navigation elements, these links should be hidden as they should only be accessible via screen readers: Yes
5. Ensure you can tab backwards through all clickable sections, and there aren’t any keyboard traps: Yes 
6. Open the screen reader, navigate through the page using the screen reader. Checking for any major issues: No obvious issues
7. If any pop ups are used on this page, ensure users can close/interact with said popup only using the keyboard: No pop ups used on this page
8. View page source code, checking that correct syntactical html has been used. For example section/article instead of div: I would change some of the divs to sections, but as the page makes use of markdown files for content, I’m unable to do this without swapping it out for html
9. Add any aria labels or aria descriptions that would be useful. For example if a section of text doesn’t have much content when consumed via a screen reader: No obscure bits of content
10. Ensure any elements that we don’t want reading out have the attribute role=’presentation’: hr (seperator) elements are needlessly being read by the screen reader so set their role as presentation

