### PR TITLE
cookie banner no longs appears when JS is disabled

### DIFF
--- a/application/templates/partials/cookie-banner.html
+++ b/application/templates/partials/cookie-banner.html
@@ -15,6 +15,9 @@
     "ariaLabel": "Cookies on planning.data.gov.uk",
     "attributes": {
       "id": "cookie-banner",
+      "aria-label":'Cookies on planning.data.gov.uk',
+      "style": 'display: none',
+      "aria-hidden": 'true',
     },
     "messages": [
       {
@@ -52,7 +55,8 @@
     'ariaLabel': "Cookies on planning.data.gov.uk",
     'attributes': {
       'id': 'cookie-confirmation',
-      'style': 'display: none'
+      'style': 'display: none',
+      'aria-hidden': 'true',
     },
     'messages': [
       {

--- a/assets/javascripts/cookies.js
+++ b/assets/javascripts/cookies.js
@@ -50,11 +50,20 @@ function hideCookieBanner () {
   }
 }
 
+function showCookieBanner () {
+  var cookieBanner = document.getElementById('cookie-banner')
+  if(cookieBanner){
+    cookieBanner.style.display = 'block'
+    cookieBanner.ariaHidden = false
+  }
+}
+
 function hideCookieConfirmation () {
   hideCookieBanner ()
   var cookieBanner = document.getElementById('cookie-confirmation')
   if(cookieBanner){
     cookieBanner.style.display = 'none'
+    cookieBanner.ariaHidden = true
   }
 }
 
@@ -62,6 +71,7 @@ function showCookieConfirmation () {
   var cookieBanner = document.getElementById('cookie-confirmation')
   if(cookieBanner){
     cookieBanner.style.display = 'block'
+    cookieBanner.ariaHidden = false
   }
 }
 
@@ -136,7 +146,7 @@ class cookiePrefs{
   }
 }
 
-
+showCookieBanner()
 if (getCookie('cookies_preferences_set')) {
   hideCookieBanner()
 }


### PR DESCRIPTION
Ticket: [https://trello.com/c/zT4Mqp56/424-disabled-javascript-causes-cookie-popup-to-remain-open](https://trello.com/c/zT4Mqp56/424-disabled-javascript-causes-cookie-popup-to-remain-open)

The cookie banner was appearing when js is disabled. you then also couldn't close it. 

this has now been rectified.

![image](https://github.com/digital-land/digital-land.info/assets/15090285/4c4fa9b7-9ab3-473a-8b07-5c812d0bc676)
