### PR TITLE
Align typologies

### DIFF
--- a/application/data_access/digital_land_queries.py
+++ b/application/data_access/digital_land_queries.py
@@ -66,6 +66,22 @@ def get_typologies() -> List[TypologyModel]:
         return [TypologyModel.from_orm(t) for t in typologies]
 
 
+# returns all typologies with at least one dataset that falls under that typology
+def get_typologies_with_dataset() -> List[TypologyModel]:
+    with get_context_session() as session:
+        typologiesNamesRes = session.query(DatasetOrm.typology).distinct().all()
+        if len(typologiesNamesRes) == 0:
+            return []
+
+        typologies = (
+            session.query(TypologyOrm)
+            .filter(TypologyOrm.typology.in_(typologiesNamesRes[0]))
+            .order_by(TypologyOrm.typology)
+            .all()
+        )
+        return [TypologyModel.from_orm(t) for t in typologies]
+
+
 def get_typology_names():
     with get_context_session() as session:
         typology_names = [

--- a/application/data_access/digital_land_queries.py
+++ b/application/data_access/digital_land_queries.py
@@ -67,9 +67,9 @@ def get_typologies() -> List[TypologyModel]:
 
 
 # returns all typologies with at least one dataset that falls under that typology
-def get_typologies_with_dataset() -> List[TypologyModel]:
+def get_typologies_with_entities() -> List[TypologyModel]:
     with get_context_session() as session:
-        typologiesNamesRes = session.query(DatasetOrm.typology).distinct().all()
+        typologiesNamesRes = session.query(EntityOrm.typology).distinct().all()
         if len(typologiesNamesRes) == 0:
             return []
 

--- a/application/data_access/digital_land_queries.py
+++ b/application/data_access/digital_land_queries.py
@@ -73,9 +73,13 @@ def get_typologies_with_dataset() -> List[TypologyModel]:
         if len(typologiesNamesRes) == 0:
             return []
 
+        typologiesNamesDict = [
+            typologiesNamesRes[i][0] for i in range(len(typologiesNamesRes))
+        ]
+
         typologies = (
             session.query(TypologyOrm)
-            .filter(TypologyOrm.typology.in_(typologiesNamesRes[0]))
+            .filter(TypologyOrm.typology.in_(typologiesNamesDict))
             .order_by(TypologyOrm.typology)
             .all()
         )

--- a/application/routers/entity.py
+++ b/application/routers/entity.py
@@ -11,7 +11,7 @@ from application.core.models import GeoJSON, EntityModel
 from application.data_access.digital_land_queries import (
     get_datasets,
     get_local_authorities,
-    get_typologies_with_dataset,
+    get_typologies_with_entities,
     get_dataset_query,
 )
 from application.data_access.entity_queries import get_entity_query, get_entity_search
@@ -178,7 +178,7 @@ def search_entities(
         geojson["links"] = links
         return geojson
 
-    typologies = get_typologies_with_dataset()
+    typologies = get_typologies_with_entities()
     typologies = [t.dict() for t in typologies]
     # dataset facet
     response = get_datasets()

--- a/application/routers/entity.py
+++ b/application/routers/entity.py
@@ -11,7 +11,7 @@ from application.core.models import GeoJSON, EntityModel
 from application.data_access.digital_land_queries import (
     get_datasets,
     get_local_authorities,
-    get_typologies,
+    get_typologies_with_dataset,
     get_dataset_query,
 )
 from application.data_access.entity_queries import get_entity_query, get_entity_search
@@ -178,8 +178,7 @@ def search_entities(
         geojson["links"] = links
         return geojson
 
-    # typology facet
-    typologies = get_typologies()
+    typologies = get_typologies_with_dataset()
     typologies = [t.dict() for t in typologies]
     # dataset facet
     response = get_datasets()

--- a/tests/unit/routers/test_entity.py
+++ b/tests/unit/routers/test_entity.py
@@ -455,7 +455,10 @@ def test_search_entities_no_entities_returned_no_query_params_html(
     mocker.patch(
         "application.routers.entity.get_datasets", return_value=multiple_dataset_models
     )
-    mocker.patch("application.routers.entity.get_typologies", return_value=typologies)
+    mocker.patch(
+        "application.routers.entity.get_typologies_with_dataset",
+        return_value=typologies,
+    )
     mocker.patch(
         "application.routers.entity.get_local_authorities",
         return_value=local_authorities,
@@ -541,7 +544,10 @@ def test_search_entities_multiple_entities_returned_no_query_params_html(
     mocker.patch(
         "application.routers.entity.get_datasets", return_value=multiple_dataset_models
     )
-    mocker.patch("application.routers.entity.get_typologies", return_value=typologies)
+    mocker.patch(
+        "application.routers.entity.get_typologies_with_dataset",
+        return_value=typologies,
+    )
     mocker.patch(
         "application.routers.entity.get_local_authorities",
         return_value=local_authorities,

--- a/tests/unit/routers/test_entity.py
+++ b/tests/unit/routers/test_entity.py
@@ -456,7 +456,7 @@ def test_search_entities_no_entities_returned_no_query_params_html(
         "application.routers.entity.get_datasets", return_value=multiple_dataset_models
     )
     mocker.patch(
-        "application.routers.entity.get_typologies_with_dataset",
+        "application.routers.entity.get_typologies_with_entities",
         return_value=typologies,
     )
     mocker.patch(
@@ -545,7 +545,7 @@ def test_search_entities_multiple_entities_returned_no_query_params_html(
         "application.routers.entity.get_datasets", return_value=multiple_dataset_models
     )
     mocker.patch(
-        "application.routers.entity.get_typologies_with_dataset",
+        "application.routers.entity.get_typologies_with_entities",
         return_value=typologies,
     )
     mocker.patch(


### PR DESCRIPTION
Ticket: [https://trello.com/c/xi56JPoP/341-align-the-typologies-shown-in-the-search-filters-with-the-typologies-shown-on-the-datasets-page](https://trello.com/c/xi56JPoP/341-align-the-typologies-shown-in-the-search-filters-with-the-typologies-shown-on-the-datasets-page)

the typologies on the search page now only show typologies that have entities of said typology

![image](https://github.com/digital-land/digital-land.info/assets/15090285/4802271a-7e11-4c75-b51c-ea852f82bfca)
