### PR TITLE
fixed beta banner styling

### DIFF
--- a/application/templates/partials/phase-banner.html
+++ b/application/templates/partials/phase-banner.html
@@ -1,11 +1,12 @@
 {% from "components/phase-banner/macro.jinja" import dlPhaseBanner %}
-{{
-  dlPhaseBanner({
-    'phase': 'Beta',
-    'html': 'This is a new service – to help us improve it, <a href="https://docs.google.com/forms/d/e/1FAIpQLSc1yzvw1Duv6nQRS56p379IxxMdAC5EfklMfUnCVMikgbi0Xw/viewform" target="_blank">sign up to take part in research</a>',
-    'classes': 'govuk-width-container govuk-width-container' if not fullWidthHeader else 'govuk-width-container govuk-grid-column-full',
-    'attributes': {
-      'style': '' if not fullWidthHeader else 'padding: 10px 30px; max-width: unset;'
-    }
-  })
-}}
+<div style="{{ '' if not fullWidthHeader else 'margin-left: auto; margin-right:  auto; max-width: 1920px;' }}">
+  {{
+    dlPhaseBanner({
+      'phase': 'Beta',
+      'html': 'This is a new service – to help us improve it, <a href="https://docs.google.com/forms/d/e/1FAIpQLSc1yzvw1Duv6nQRS56p379IxxMdAC5EfklMfUnCVMikgbi0Xw/viewform" target="_blank">sign up to take part in research</a>',
+      'attributes': {
+        'style': '' if not fullWidthHeader else 'padding: 10px 30px;'
+      }
+    })
+  }}
+</div>


### PR DESCRIPTION
Ticket: https://trello.com/c/g9SpANci/436-zooming-out-causes-beta-bar-to-format-incorrectly

the beta banner on the map page was styled incorrectly when zooming out

# Before
![image](https://github.com/digital-land/digital-land.info/assets/15090285/b9bfe25e-dd10-4795-8b1e-2720bbf4dc55)
# After
![image](https://github.com/digital-land/digital-land.info/assets/15090285/68f206b1-940a-4872-ad2b-eadd692b97cc)

