### PR TITLE
popup now doesn't have a scroll event handler

### DIFF
--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -412,7 +412,16 @@ export default class MapController {
     const wrapper = document.createElement('div');
     wrapper.classList.add('app-popup');
     wrapper.onwheel = (e) => {
-      e.preventDefault();
+      let list = e.target.closest('.app-popup-list');
+
+      if(!list){
+        e.preventDefault();
+        return
+      }
+
+      var verticalScroll = list.scrollHeight > list.clientHeight;
+      if(!verticalScroll)
+        e.preventDefault();
     };
 
     const featureOrFeatures = features.length > 1 ? 'features' : 'feature';

--- a/tests/integration/javascript/MapController.test.js
+++ b/tests/integration/javascript/MapController.test.js
@@ -494,24 +494,11 @@ describe('Map Controller', () => {
 
         expect(maplibregl.Popup).toHaveBeenCalledOnce();
         expect(popupMock.setLngLat).toHaveBeenCalledOnce();
-        expect(popupMock.setHTML).toHaveBeenCalledOnce();
+        expect(popupMock.setDOMContent).toHaveBeenCalledOnce();
         expect(popupMock.addTo).toHaveBeenCalledOnce();
         expect(popupMock.setLngLat).toHaveBeenCalledWith(mockClickEvent.lngLat);
 
-        const expectedHTML = `<div class=\"app-popup\"><h3 class=\"app-popup-heading\">2 features selected</h3><ul class=\"app-popup-list\">
-<li class=\"app-popup-item\" style=\"border-left: 5px solid red\">
-<p class=\"app-u-secondary-text govuk-!-margin-bottom-0 govuk-!-margin-top-0\">TestSourceLayer</p>
-<p class=\"dl-small-text govuk-!-margin-top-0 govuk-!-margin-bottom-0\">
-<a class='govuk-link' href=\"/entity/testEntity\">testName</a>
-</p>
-</li><li class=\"app-popup-item\" style=\"border-left: 5px solid red\">
-<p class=\"app-u-secondary-text govuk-!-margin-bottom-0 govuk-!-margin-top-0\">TestSourceLayer</p>
-<p class=\"dl-small-text govuk-!-margin-top-0 govuk-!-margin-bottom-0\">
-<a class='govuk-link' href=\"/entity/testEntity2\">testName2</a>
-</p>
-</li></ul></div>`;
-
-        expect(popupMock.setHTML).toHaveBeenCalledWith(expectedHTML);
+        expect(popupMock.setDOMContent).toHaveBeenCalledOnce();
         expect(popupMock.addTo).toHaveBeenCalledWith(mapController.map);
     })
 })

--- a/tests/unit/javascript/MapController.test.js
+++ b/tests/unit/javascript/MapController.test.js
@@ -1,6 +1,7 @@
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 import MapController from '../../../assets/javascripts/MapController'
 import {
+    stubGlobalDocument,
     stubGlobalFetch,
     stubGlobalMapLibre, stubGlobalTurf, waitForMapCreation
 } from '../../utils/mockUtils.js';
@@ -412,6 +413,9 @@ describe('Map Controller - Unit', () => {
     })
 
     describe('createFeaturesPopupHtml()', () => {
+
+        stubGlobalDocument();
+
         test('correctly creates a popup', () => {
             mapController.getFillColour = vi.fn().mockImplementation(() => {
                 return 'red'
@@ -428,10 +432,10 @@ describe('Map Controller - Unit', () => {
                 },
             ]
 
-            const html = mapController.createFeaturesPopupHtml(mockFeatures)
+            const popup = mapController.createFeaturesPopup(mockFeatures)
 
-            expect(html).toContain('testName1')
-            expect(html).toContain(`href="/entity/${mockFeatures[0].properties.entity}`)
+            expect(popup.textContent).toContain('testName1')
+            expect(popup.href).toContain(`/entity/${mockFeatures[0].properties.entity}`)
         })
 
         test('correctly creates a popup for a feature without a name', () => {
@@ -450,11 +454,12 @@ describe('Map Controller - Unit', () => {
                 },
             ]
 
-            const html = mapController.createFeaturesPopupHtml(mockFeatures)
+            const popup = mapController.createFeaturesPopup(mockFeatures)
 
-            expect(html).toContain('testReference1')
-            expect(html).toContain(`href="/entity/${mockFeatures[0].properties.entity}`)
-            expect(html).toContain('border-left: 5px solid red')
+            expect(popup.textContent).toEqual('testReference1')
+            expect(popup.href).toEqual(`/entity/${mockFeatures[0].properties.entity}`)
+            expect(popup.style).toHaveProperty('borderLeft')
+            expect(popup.style.borderLeft).toEqual('5px solid red')
         })
 
         test('correctly creates a popup for a feature without a name or reference', () => {
@@ -473,10 +478,10 @@ describe('Map Controller - Unit', () => {
                 },
             ]
 
-            const html = mapController.createFeaturesPopupHtml(mockFeatures)
+            const domElement = mapController.createFeaturesPopup(mockFeatures)
 
-            expect(html).toContain('Not Named')
-            expect(html).toContain(`href="/entity/${mockFeatures[0].properties.entity}`)
+            expect(domElement.textContent).toEqual('Not Named')
+            expect(domElement.href).toEqual(`/entity/${mockFeatures[0].properties.entity}`)
         })
 
     })

--- a/tests/utils/mockUtils.js
+++ b/tests/utils/mockUtils.js
@@ -76,6 +76,9 @@ const domElementMock = {
         remove: vi.fn(),
         add: vi.fn(),
     },
+    style: {
+
+    },
     dataset: {
         layerControl: 'testLayer1',
     },
@@ -90,6 +93,7 @@ const popupMock = {
     setLngLat: vi.fn().mockImplementation(() => popupMock),
     setHTML: vi.fn().mockImplementation(() => popupMock),
     addTo: vi.fn().mockImplementation(() => popupMock),
+    setDOMContent: vi.fn().mockImplementation(() => popupMock),
 }
 
 


### PR DESCRIPTION
Ticket: [https://trello.com/c/EuG6jsW0/389-bug-fix-mouse-events-on-feature-popups](https://trello.com/c/EuG6jsW0/389-bug-fix-mouse-events-on-feature-popups)

Using the mouse wheel when hovering over a feature popup would initiate a scroll action. this was jarring and has been removed for accessibility

![image](https://github.com/digital-land/digital-land.info/assets/15090285/493c7dc4-cc45-406c-9ffc-0561ccded6a4)


