### PR TITLE
Layer controls

### DIFF
--- a/application/templates/components/map/macro.jinja
+++ b/application/templates/components/map/macro.jinja
@@ -23,26 +23,7 @@
         </div>
 
       {% if params.enableLayerControls -%}
-        <div class="dl-map__side-panel dl-map__side-panel--full" tabindex="-1" role="dialog" aria-hidden="false" open="true" aria-modal="true">
-            <div class="dl-map__side-panel__heading">
-              <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Data layers</h3>
-            </div>
-            <div class="dl-map__side-panel__content">
-              <div class="govuk-checkboxes" data-module="layer-controls-{{ params.mapId if params.mapId else 'map' }}">
-                <div class="dl-filter-group__auto-filter">
-                  <label for="input-71108" class="govuk-label govuk-visually-hidden">
-                    Filter Show only
-                  </label>
-                  <input id="input-71108" class="govuk-input dl-filter-group__auto-filter__input" type="text" aria-describedby="checkbox-filter-71108" aria-controls="checkboxes-71108">
-                </div>
-                <ul class="govuk-list govuk-!-margin-bottom-0" data-module="layer-toggles" role="group">
-                  {% for layer in params.layers %}
-                    {{ layerControlItem(layer) }}
-                  {% endfor %}
-              </ul>
-            </div>
-          </div>
-        </div>
+
       {% endif -%}
 
         {#- Set the loader div #}
@@ -106,6 +87,7 @@
             enabled: true,
           },
           useOAuth2: true,
+          layers: layers,
         };
 
         window.mapControllers = window.mapControllers || {};
@@ -121,45 +103,45 @@
 {% macro layerControlItem(layer) %}
     <li class="dl-map__layer-item govuk-!-margin-bottom-1" data-layer-control="{{ layer.dataset }}"
     {% if layer.paint_options.type %}data-layer-type={{layer.paint_options.type}}{% endif %} data-style-options="{% if layer.paint_options %}{{ layer.paint_options.colour }},{{ layer.paint_options.opacity }}{% endif %}">
-    <div class="govuk-checkboxes__item">
-        <input class="govuk-checkboxes__input" id="{{ layer.dataset }}" name="{{ layer.dataset }}" type="checkbox" value="{{ layer.dataset }}" {{ "checked='checked'" if layer.checked }}>
-        <label class="govuk-label govuk-checkboxes__label" for="{{ layer.dataset }}">
-        <span class="dl-label__key">
-            {%- if layer.paint_options.type and layer.paint_options.type == 'point' -%}
-                <svg class="dl-label__key__symbol--pin" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" xml:space="preserve" viewBox="0 0 90 90">
+      <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="{{ layer.dataset }}" name="{{ layer.dataset }}" type="checkbox" value="{{ layer.dataset }}" {{ "checked='checked'" if layer.checked }}>
+          <label class="govuk-label govuk-checkboxes__label" for="{{ layer.dataset }}">
+          <span class="dl-label__key">
+              {%- if layer.paint_options.type and layer.paint_options.type == 'point' -%}
+                  <svg class="dl-label__key__symbol--pin" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" xml:space="preserve" viewBox="0 0 90 90">
 
-                  <defs>
-                  </defs>
-                  <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" >
-                    <path
-                      d="M 45 0 C 27.677 0 13.584 14.093 13.584 31.416 c 0 4.818 1.063 9.442 3.175 13.773 c 2.905 5.831 11.409 20.208 20.412 35.428 l 4.385 7.417 C 42.275 89.252 43.585 90 45 90 s 2.725 -0.748 3.444 -1.966 l 4.382 -7.413 c 8.942 -15.116 17.392 -29.4 20.353 -35.309 c 0.027 -0.051 0.055 -0.103 0.08 -0.155 c 2.095 -4.303 3.157 -8.926 3.157 -13.741 C 76.416 14.093 62.323 0 45 0 z M 45 42.81 c -6.892 0 -12.5 -5.607 -12.5 -12.5 c 0 -6.893 5.608 -12.5 12.5 -12.5 c 6.892 0 12.5 5.608 12.5 12.5 C 57.5 37.202 51.892 42.81 45 42.81 z"
-                      style="
-                        stroke: none;
-                        stroke-width: 1;
-                        stroke-dasharray: none;
-                        stroke-linecap: butt;
-                        stroke-linejoin: miter;
-                        stroke-miterlimit: 10;
-                        fill: {{layer.paint_options.colour|default('#003078')}};
-                        fill-rule: nonzero;
-                        opacity: 1;"
-                        transform=" matrix(1 0 0 1 0 0) "
-                        stroke-linecap="round"
-                      />
-                  </g>
-                </svg>
-            {%- else -%}
-              <span
-                class="dl-label__key__symbol"
-                style="
-                  border-color: {{layer.paint_options.colour|default('#003078')}};
-                  background: rgba({{layer.paint_options.colour|default('#003078')|hex_to_rgb}},{{ layer.paint_options.opacity|default('0.5') }});"
-                >
-              </span>
-            {%- endif -%}
-            {{ layer.name }}
-        </span>
-        </label>
-    </div>
+                    <defs>
+                    </defs>
+                    <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" >
+                      <path
+                        d="M 45 0 C 27.677 0 13.584 14.093 13.584 31.416 c 0 4.818 1.063 9.442 3.175 13.773 c 2.905 5.831 11.409 20.208 20.412 35.428 l 4.385 7.417 C 42.275 89.252 43.585 90 45 90 s 2.725 -0.748 3.444 -1.966 l 4.382 -7.413 c 8.942 -15.116 17.392 -29.4 20.353 -35.309 c 0.027 -0.051 0.055 -0.103 0.08 -0.155 c 2.095 -4.303 3.157 -8.926 3.157 -13.741 C 76.416 14.093 62.323 0 45 0 z M 45 42.81 c -6.892 0 -12.5 -5.607 -12.5 -12.5 c 0 -6.893 5.608 -12.5 12.5 -12.5 c 6.892 0 12.5 5.608 12.5 12.5 C 57.5 37.202 51.892 42.81 45 42.81 z"
+                        style="
+                          stroke: none;
+                          stroke-width: 1;
+                          stroke-dasharray: none;
+                          stroke-linecap: butt;
+                          stroke-linejoin: miter;
+                          stroke-miterlimit: 10;
+                          fill: {{layer.paint_options.colour|default('#003078')}};
+                          fill-rule: nonzero;
+                          opacity: 1;"
+                          transform=" matrix(1 0 0 1 0 0) "
+                          stroke-linecap="round"
+                        />
+                    </g>
+                  </svg>
+              {%- else -%}
+                <span
+                  class="dl-label__key__symbol"
+                  style="
+                    border-color: {{layer.paint_options.colour|default('#003078')}};
+                    background: rgba({{layer.paint_options.colour|default('#003078')|hex_to_rgb}},{{ layer.paint_options.opacity|default('0.5') }});"
+                  >
+                </span>
+              {%- endif -%}
+              {{ layer.name }}
+          </span>
+          </label>
+      </div>
     </li>
 {% endmacro %}

--- a/application/templates/components/map/macro.jinja
+++ b/application/templates/components/map/macro.jinja
@@ -22,10 +22,6 @@
             <noscript>To view this map, you need to enable JavaScript.</noscript>
         </div>
 
-      {% if params.enableLayerControls -%}
-
-      {% endif -%}
-
         {#- Set the loader div #}
         {% if params.loader -%}
             <div class="dl-map__loader">
@@ -103,45 +99,45 @@
 {% macro layerControlItem(layer) %}
     <li class="dl-map__layer-item govuk-!-margin-bottom-1" data-layer-control="{{ layer.dataset }}"
     {% if layer.paint_options.type %}data-layer-type={{layer.paint_options.type}}{% endif %} data-style-options="{% if layer.paint_options %}{{ layer.paint_options.colour }},{{ layer.paint_options.opacity }}{% endif %}">
-      <div class="govuk-checkboxes__item">
-          <input class="govuk-checkboxes__input" id="{{ layer.dataset }}" name="{{ layer.dataset }}" type="checkbox" value="{{ layer.dataset }}" {{ "checked='checked'" if layer.checked }}>
-          <label class="govuk-label govuk-checkboxes__label" for="{{ layer.dataset }}">
-          <span class="dl-label__key">
-              {%- if layer.paint_options.type and layer.paint_options.type == 'point' -%}
-                  <svg class="dl-label__key__symbol--pin" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" xml:space="preserve" viewBox="0 0 90 90">
+    <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="{{ layer.dataset }}" name="{{ layer.dataset }}" type="checkbox" value="{{ layer.dataset }}" {{ "checked='checked'" if layer.checked }}>
+        <label class="govuk-label govuk-checkboxes__label" for="{{ layer.dataset }}">
+        <span class="dl-label__key">
+            {%- if layer.paint_options.type and layer.paint_options.type == 'point' -%}
+                <svg class="dl-label__key__symbol--pin" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" xml:space="preserve" viewBox="0 0 90 90">
 
-                    <defs>
-                    </defs>
-                    <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" >
-                      <path
-                        d="M 45 0 C 27.677 0 13.584 14.093 13.584 31.416 c 0 4.818 1.063 9.442 3.175 13.773 c 2.905 5.831 11.409 20.208 20.412 35.428 l 4.385 7.417 C 42.275 89.252 43.585 90 45 90 s 2.725 -0.748 3.444 -1.966 l 4.382 -7.413 c 8.942 -15.116 17.392 -29.4 20.353 -35.309 c 0.027 -0.051 0.055 -0.103 0.08 -0.155 c 2.095 -4.303 3.157 -8.926 3.157 -13.741 C 76.416 14.093 62.323 0 45 0 z M 45 42.81 c -6.892 0 -12.5 -5.607 -12.5 -12.5 c 0 -6.893 5.608 -12.5 12.5 -12.5 c 6.892 0 12.5 5.608 12.5 12.5 C 57.5 37.202 51.892 42.81 45 42.81 z"
-                        style="
-                          stroke: none;
-                          stroke-width: 1;
-                          stroke-dasharray: none;
-                          stroke-linecap: butt;
-                          stroke-linejoin: miter;
-                          stroke-miterlimit: 10;
-                          fill: {{layer.paint_options.colour|default('#003078')}};
-                          fill-rule: nonzero;
-                          opacity: 1;"
-                          transform=" matrix(1 0 0 1 0 0) "
-                          stroke-linecap="round"
-                        />
-                    </g>
-                  </svg>
-              {%- else -%}
-                <span
-                  class="dl-label__key__symbol"
-                  style="
-                    border-color: {{layer.paint_options.colour|default('#003078')}};
-                    background: rgba({{layer.paint_options.colour|default('#003078')|hex_to_rgb}},{{ layer.paint_options.opacity|default('0.5') }});"
-                  >
-                </span>
-              {%- endif -%}
-              {{ layer.name }}
-          </span>
-          </label>
-      </div>
+                  <defs>
+                  </defs>
+                  <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" >
+                    <path
+                      d="M 45 0 C 27.677 0 13.584 14.093 13.584 31.416 c 0 4.818 1.063 9.442 3.175 13.773 c 2.905 5.831 11.409 20.208 20.412 35.428 l 4.385 7.417 C 42.275 89.252 43.585 90 45 90 s 2.725 -0.748 3.444 -1.966 l 4.382 -7.413 c 8.942 -15.116 17.392 -29.4 20.353 -35.309 c 0.027 -0.051 0.055 -0.103 0.08 -0.155 c 2.095 -4.303 3.157 -8.926 3.157 -13.741 C 76.416 14.093 62.323 0 45 0 z M 45 42.81 c -6.892 0 -12.5 -5.607 -12.5 -12.5 c 0 -6.893 5.608 -12.5 12.5 -12.5 c 6.892 0 12.5 5.608 12.5 12.5 C 57.5 37.202 51.892 42.81 45 42.81 z"
+                      style="
+                        stroke: none;
+                        stroke-width: 1;
+                        stroke-dasharray: none;
+                        stroke-linecap: butt;
+                        stroke-linejoin: miter;
+                        stroke-miterlimit: 10;
+                        fill: {{layer.paint_options.colour|default('#003078')}};
+                        fill-rule: nonzero;
+                        opacity: 1;"
+                        transform=" matrix(1 0 0 1 0 0) "
+                        stroke-linecap="round"
+                      />
+                  </g>
+                </svg>
+            {%- else -%}
+              <span
+                class="dl-label__key__symbol"
+                style="
+                  border-color: {{layer.paint_options.colour|default('#003078')}};
+                  background: rgba({{layer.paint_options.colour|default('#003078')|hex_to_rgb}},{{ layer.paint_options.opacity|default('0.5') }});"
+                >
+              </span>
+            {%- endif -%}
+            {{ layer.name }}
+        </span>
+        </label>
+    </div>
     </li>
 {% endmacro %}

--- a/application/templates/pages/guidance/introduction.md
+++ b/application/templates/pages/guidance/introduction.md
@@ -31,7 +31,7 @@ By publishing your data, you will be helping to create a national resource of op
 What data we collect
 --------------------
 
-Planning Data collects [data about a range of subjects](https://www.digital-land.info/dataset/#monitoring).
+Planning Data collects [data about a range of subjects](https://www.digital-land.info/dataset).
 
 There are 4 main data subjects that are needed for the RIPA service:
 

--- a/assets/javascripts/LayerControls.js
+++ b/assets/javascripts/LayerControls.js
@@ -4,7 +4,84 @@ export default class LayerControls {
       this.mapController = mapController;
       this.tileSource = source;
       this.availableLayers = availableLayers;
-      this.init(options);
+
+      this._container = document.createElement('div');
+      this.layerOptions = [];
+
+		  const styleClasses = this._container.classList;
+
+      // this.init(options);
+    }
+
+    onAdd(map) {
+      const sidePanel = document.createElement('div');
+      sidePanel.classList.add('dl-map__side-panel');
+      sidePanel.setAttribute('tabindex', '-1');
+      sidePanel.setAttribute('role', 'dialog');
+      sidePanel.setAttribute('aria-hidden', 'false');
+      sidePanel.setAttribute('open', 'true');
+      sidePanel.setAttribute('aria-modal', 'true');
+
+      const heading = document.createElement('div');
+      heading.classList.add('dl-map__side-panel__heading');
+
+      const h3 = document.createElement('h3');
+      h3.classList.add('govuk-heading-s', 'govuk-!-margin-bottom-0');
+      h3.textContent = 'Data layers';
+
+      heading.appendChild(h3);
+      sidePanel.appendChild(heading);
+
+      const content = document.createElement('div');
+      content.classList.add('dl-map__side-panel__content');
+
+      const checkboxes = document.createElement('div');
+      checkboxes.classList.add('govuk-checkboxes');
+      checkboxes.setAttribute('data-module', 'layer-controls-{{ params.mapId if params.mapId else \'map\' }}');
+
+      const filterGroup = document.createElement('div');
+      filterGroup.classList.add('dl-filter-group__auto-filter');
+
+      const filterLabel = document.createElement('label');
+      filterLabel.setAttribute('for', 'input-71108');
+      filterLabel.classList.add('govuk-label', 'govuk-visually-hidden');
+      filterLabel.textContent = 'Filter Show only';
+
+      const filterInput = document.createElement('input');
+      filterInput.setAttribute('id', 'input-71108');
+      filterInput.classList.add('govuk-input', 'dl-filter-group__auto-filter__input');
+      filterInput.setAttribute('type', 'text');
+      filterInput.setAttribute('aria-describedby', 'checkbox-filter-71108');
+      filterInput.setAttribute('aria-controls', 'checkboxes-71108');
+
+      filterGroup.appendChild(filterLabel);
+      filterGroup.appendChild(filterInput);
+      checkboxes.appendChild(filterGroup);
+
+      const list = document.createElement('ul');
+      list.classList.add('govuk-list', 'govuk-!-margin-bottom-0');
+      list.setAttribute('data-module', 'layer-toggles');
+      list.setAttribute('role', 'group');
+
+
+
+      this.availableLayers.forEach((layer) => {
+        const item = new LayerOption(layer);
+        this.layerOptions.push(item);
+        list.appendChild(item.getElement());
+      });
+
+      checkboxes.appendChild(list);
+      content.appendChild(checkboxes);
+      sidePanel.appendChild(content);
+
+      this._container.appendChild(sidePanel);
+
+      return this._container;
+    }
+
+    onRemove() {
+
     }
 
     init(params) {
@@ -262,4 +339,95 @@ export default class LayerControls {
         cb();
       }
     };
+}
+
+class LayerOption {
+  constructor(layer){
+    this.layer = layer;
+    this.element = this.makeElement(layer);
+  }
+
+  makeElement(layer) {
+    const listItem = document.createElement('li');
+    listItem.classList.add("dl-map__layer-item");
+    listItem.classList.add("govuk-!-margin-bottom-1");
+
+    const checkBoxDiv = document.createElement('div');
+    checkBoxDiv.classList.add("govuk-checkboxes__item");
+
+    const checkBoxInput = document.createElement('input');
+    checkBoxInput.classList.add("govuk-checkboxes__input");
+    checkBoxInput.setAttribute('id', layer.dataset);
+    checkBoxInput.setAttribute('name', layer.dataset);
+    checkBoxInput.setAttribute('type', 'checkbox');
+    checkBoxInput.setAttribute('value', layer.dataset);
+    checkBoxInput.setAttribute('checked', 'checked');
+
+    const checkBoxLabel = document.createElement('label');
+    checkBoxLabel.classList.add("govuk-label");
+    checkBoxLabel.classList.add("govuk-checkboxes__label");
+    checkBoxLabel.setAttribute('for', layer.dataset);
+    checkBoxLabel.innerHTML = this.makeLayerSymbol(layer);
+
+    checkBoxDiv.appendChild(checkBoxInput);
+    checkBoxDiv.appendChild(checkBoxLabel);
+    listItem.appendChild(checkBoxDiv);
+
+    return listItem;
+  }
+
+  makeLayerSymbol(layer) {
+
+    let symbolHtml = '';
+
+    if(layer.paint_options.type && layer.paint_options.type == 'point') {
+      symbolHtml = `
+        <svg class="dl-label__key__symbol--pin" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" xml:space="preserve" viewBox="0 0 90 90">
+          <defs>
+          </defs>
+          <g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" >
+            <path
+              d="M 45 0 C 27.677 0 13.584 14.093 13.584 31.416 c 0 4.818 1.063 9.442 3.175 13.773 c 2.905 5.831 11.409 20.208 20.412 35.428 l 4.385 7.417 C 42.275 89.252 43.585 90 45 90 s 2.725 -0.748 3.444 -1.966 l 4.382 -7.413 c 8.942 -15.116 17.392 -29.4 20.353 -35.309 c 0.027 -0.051 0.055 -0.103 0.08 -0.155 c 2.095 -4.303 3.157 -8.926 3.157 -13.741 C 76.416 14.093 62.323 0 45 0 z M 45 42.81 c -6.892 0 -12.5 -5.607 -12.5 -12.5 c 0 -6.893 5.608 -12.5 12.5 -12.5 c 6.892 0 12.5 5.608 12.5 12.5 C 57.5 37.202 51.892 42.81 45 42.81 z"
+              style="
+                stroke: none;
+                stroke-width: 1;
+                stroke-dasharray: none;
+                stroke-linecap: butt;
+                stroke-linejoin: miter;
+                stroke-miterlimit: 10;
+                fill:${layer.paint_options.colour|'#003078'};
+                fill-rule: nonzero;
+                opacity: 1;"
+                transform=" matrix(1 0 0 1 0 0) "
+                stroke-linecap="round"
+              />
+          </g>
+        </svg>`
+    } else {
+      layer.paint_options.opacity = layer.paint_options.opacity || 0.5;
+      const opacity = parseInt((layer.paint_options.opacity * 255)).toString(16);
+      symbolHtml = `
+        <span
+          class="dl-label__key__symbol"
+          style="
+            border-color: ${layer.paint_options.colour || '#003078'};
+            background: ${(layer.paint_options.colour || '#003078')}${opacity};
+          "
+        >
+        </span>
+      `
+    }
+
+    const html = `<span class="dl-label__key">${symbolHtml}</span>`;
+    return html;
+  }
+
+
+  getElement() {
+    return this.element;
+  }
+
+  clickHandler() {
+
+  }
 }

--- a/assets/javascripts/LayerControls.js
+++ b/assets/javascripts/LayerControls.js
@@ -20,10 +20,6 @@ export default class LayerControls {
       window.addEventListener('popstate', function (event) {
         boundSetControls();
       });
-
-
-
-      // this.init(options);
     }
 
     onAdd(map) {
@@ -61,15 +57,16 @@ export default class LayerControls {
       filterLabel.classList.add('govuk-label', 'govuk-visually-hidden');
       filterLabel.textContent = 'Filter Show only';
 
-      const filterInput = document.createElement('input');
-      filterInput.setAttribute('id', 'input-71108');
-      filterInput.classList.add('govuk-input', 'dl-filter-group__auto-filter__input');
-      filterInput.setAttribute('type', 'text');
-      filterInput.setAttribute('aria-describedby', 'checkbox-filter-71108');
-      filterInput.setAttribute('aria-controls', 'checkboxes-71108');
+      this.$textbox = document.createElement('input');
+      this.$textbox.setAttribute('id', 'input-71108');
+      this.$textbox.classList.add('govuk-input', 'dl-filter-group__auto-filter__input');
+      this.$textbox.setAttribute('type', 'text');
+      this.$textbox.setAttribute('aria-describedby', 'checkbox-filter-71108');
+      this.$textbox.setAttribute('aria-controls', 'checkboxes-71108');
+      this.$textbox.addEventListener('input', this.filterCheckboxes.bind(this));
 
       filterGroup.appendChild(filterLabel);
-      filterGroup.appendChild(filterInput);
+      filterGroup.appendChild(this.$textbox);
       checkboxes.appendChild(filterGroup);
 
       const list = document.createElement('ul');
@@ -138,9 +135,7 @@ export default class LayerControls {
     init(params) {
       this.setupOptions(params);
 
-      // find the search box
-      this.$textbox = this.$module.querySelector('.dl-filter-group__auto-filter__input');
-      this.$textbox.addEventListener('input', this.filterCheckboxes.bind(this));
+
 
       // get the aria description element
       this.ariaDescription = this.$module.querySelector('.dl-filter-group__auto-filter__desc');
@@ -229,19 +224,14 @@ export default class LayerControls {
     };
 
     filterCheckboxesArr(query) {
-      var checkboxArr = this.checkboxArr;
-      return checkboxArr.filter((el) => {
-        const checkbox = el.querySelector('label');
-        return checkbox.textContent.toLowerCase().indexOf(query.toLowerCase()) !== -1
-      })
+      return this.layerOptions.filter(layerOption => layerOption.getDatasetName().toLowerCase().indexOf(query.toLowerCase()) !== -1)
     };
 
-    displayMatchingCheckboxes(checkboxArray, cb) {
+    displayMatchingCheckboxes(layerOptions, cb) {
       // hide all
-      this.checkboxArr.forEach((checkBox) => {checkBox.style.display = 'none';});
+      this.layerOptions.forEach(layerOption => layerOption.setLayerCheckboxVisibility(false));
       // re show those in filtered array
-      checkboxArray.forEach((checkBox) => {checkBox.style.display = 'block';});
-
+      layerOptions.forEach(layerOption => layerOption.setLayerCheckboxVisibility(true));
       if (cb) {
         cb();
       }
@@ -354,7 +344,7 @@ class LayerOption {
     $chkbx.checked = true;
     this.element.dataset.layerControlActive = 'true';
     this.element.classList.remove(this.layerControlDeactivatedClass);
-    this.toggleLayerVisibility(true);
+    this.setLayerVisibility(true);
   };
 
   disable() {
@@ -362,12 +352,17 @@ class LayerOption {
     $chkbx.checked = false;
     this.element.dataset.layerControlActive = 'false';
     this.element.classList.add(this.layerControlDeactivatedClass);
-    this.toggleLayerVisibility(false);
+    this.setLayerVisibility(false);
   };
 
-  toggleLayerVisibility(toEnable) {
-    const visibility = (toEnable) ? 'visible' : 'none';
+  setLayerVisibility(visible) {
+    const visibility = (visible) ? 'visible' : 'none';
     this.availableLayers.forEach(layerId => this.layerControls.mapController.setLayerVisibility(layerId, visibility));
+  }
+
+  setLayerCheckboxVisibility(display) {
+    const displayString = display ? 'block' : 'none';
+    this.element.style.display = displayString;
   }
 
   getDatasetName(){

--- a/assets/javascripts/LayerControls.js
+++ b/assets/javascripts/LayerControls.js
@@ -1,8 +1,7 @@
 import {defaultPaintOptions} from "./defaultPaintOptions.js";
 
 export default class LayerControls {
-    constructor ($module, mapController, source, layers, availableLayers, options) {
-      this.$module = $module;
+    constructor (mapController, source, layers, availableLayers, options) {
       this.mapController = mapController;
       this.tileSource = source;
       this.layers = layers;

--- a/assets/javascripts/LayerControls.js
+++ b/assets/javascripts/LayerControls.js
@@ -223,6 +223,21 @@ export default class LayerControls {
       window.history.pushState({}, '', newURL);
       this.toggleLayersBasedOnUrl();
     }
+
+    getClickableLayers() {
+      var clickableLayers = [];
+      var enabledLayers = this.enabledLayers().map(layer => layer.getDatasetName());
+
+      return enabledLayers.map((layer) => {
+        var components = this.availableLayers[layer];
+
+        if (components.includes(layer + 'Fill')) {
+          return layer + 'Fill';
+        }
+
+        return components[0];
+      });
+    }
 }
 
 export class LayerOption {

--- a/assets/javascripts/LayerControls.js
+++ b/assets/javascripts/LayerControls.js
@@ -70,7 +70,8 @@ export default class LayerControls {
       checkboxes.appendChild(filterGroup);
 
       const list = document.createElement('ul');
-      list.classList.add('govuk-list', 'govuk-!-margin-bottom-0');
+      list.classList.add('govuk-list');
+      list.setAttribute('style', 'height: 400px;')
       list.setAttribute('data-module', 'layer-toggles');
       list.setAttribute('role', 'group');
 

--- a/assets/javascripts/LayerControls.js
+++ b/assets/javascripts/LayerControls.js
@@ -213,19 +213,6 @@ export default class LayerControls {
       disabledLayers.forEach(layer => layer.disable());
     }
 
-    updateUrl() {
-      // set the url params based on the enabled layers
-      const urlParams = (new URL(document.location)).searchParams;
-      const enabledLayers = this.enabledLayers();
-      urlParams.delete(this.layerURLParamName);
-      enabledLayers.forEach(layer => urlParams.append(this.layerURLParamName, layer.getDatasetName()));
-      const newURL = window.location.pathname + '?' + urlParams.toString() + window.location.hash;
-
-      // add entry to history, does not fire event so need to call toggleLayersBasedOnUrl
-      window.history.pushState({}, '', newURL);
-      this.toggleLayersBasedOnUrl();
-    };
-
     enabledLayers() {
       return this.layerOptions.filter(option => option.element.querySelector('input[type="checkbox"]').checked)
     };
@@ -233,38 +220,6 @@ export default class LayerControls {
     disabledLayers() {
       return this.$controls.filter($control => !option.element.querySelector('input[type="checkbox"]').checked)
     };
-
-    getControlByName(dataset) {
-      for (let i = 0; i < this.$controls.length; i++) {
-        const $control = this.$controls[i];
-        if ($control.dataset.layerControl === dataset) {
-          return $control
-        }
-      }
-      return undefined
-    };
-
-    onControlChkbxChange = function (e) {
-      // when a control is changed update the URL params
-      this.updateUrl();
-    };
-
-    getClickableLayers() {
-      var clickableLayers = [];
-      var enabledLayers = this.enabledLayers().map(layer => layer.getDatasetName());
-
-      var clickableLayers = enabledLayers.map((layer) => {
-        var components = this.availableLayers[layer];
-
-        if (components.includes(layer + 'Fill')) {
-          return layer + 'Fill';
-        }
-
-        return components[0];
-      });
-
-      return clickableLayers;
-    }
 
     filterCheckboxes(e) {
       // get the value of the search box

--- a/assets/javascripts/LayerControls.js
+++ b/assets/javascripts/LayerControls.js
@@ -133,24 +133,6 @@ export default class LayerControls {
 
     }
 
-    init(params) {
-      this.setupOptions(params);
-
-
-
-      // get the aria description element
-      this.ariaDescription = this.$module.querySelector('.dl-filter-group__auto-filter__desc');
-
-      return this
-    };
-
-    setupOptions(params) {
-      params = params || {};
-      this.layerControlDeactivatedClass = params.layerControlDeactivatedClass || 'deactivated-control';
-      this.layerURLParamName = params.layerURLParamName || 'layer';
-      this.listItemSelector = params.listItemSelector || '.govuk-checkboxes__item';
-    };
-
     togglePanel(e) {
       const action = e.target.dataset.action;
       const opening = (action === 'open');
@@ -172,8 +154,7 @@ export default class LayerControls {
       }
     };
 
-
-      // toggles visibility of elements/entities based on URL params
+    // toggles visibility of elements/entities based on URL params
     toggleLayersBasedOnUrl() {
       const enabledLayers = this.getEnabledLayersFromUrl();
       this.showEntitiesForLayers(enabledLayers);
@@ -189,8 +170,8 @@ export default class LayerControls {
       if (urlParams.has(this.layerURLParamName)) {
           enabledLayerNames = urlParams
             .getAll(this.layerURLParamName)
-            .filter(name => this.layerOptions.find((option) => option.layer.dataset == name) != undefined)
-            .map(name => this.layerOptions.find((option) => option.layer.dataset == name));
+            .filter(name => this.layerOptions.find((option) => option.getDatasetName() == name) != undefined)
+            .map(name => this.layerOptions.find((option) => option.getDatasetName() == name));
       }
 
       return enabledLayerNames;
@@ -207,18 +188,10 @@ export default class LayerControls {
     }
 
     enabledLayers() {
-      return this.layerOptions.filter(option => option.element.querySelector('input[type="checkbox"]').checked)
-    };
-
-    disabledLayers() {
-      return this.$controls.filter($control => !option.element.querySelector('input[type="checkbox"]').checked)
+      return this.layerOptions.filter(option => option.isChecked())
     };
 
     filterCheckboxes(e) {
-      // get the value of the search box
-      // get an array of filtered controls based on the value
-      // render those controls to the layer control panel
-
       var query = e.target.value;
       var filteredCheckboxes = this.filterCheckboxesArr(query);
       this.displayMatchingCheckboxes(filteredCheckboxes)
@@ -252,7 +225,7 @@ export default class LayerControls {
     }
 }
 
-class LayerOption {
+export class LayerOption {
   constructor(layer, availableLayers, layerControls){
     this.layer = layer;
     this.element = this.makeElement(layer);
@@ -309,7 +282,7 @@ class LayerOption {
                 stroke-linecap: butt;
                 stroke-linejoin: miter;
                 stroke-miterlimit: 10;
-                fill:${layer.paint_options.colour||defaultPaintOptions["fill-color"]};
+                fill: ${layer.paint_options.colour||defaultPaintOptions["fill-color"]};
                 fill-rule: nonzero;
                 opacity: ${layer.paint_options.opacity||defaultPaintOptions["fill-opacity"]};"
                 transform=" matrix(1 0 0 1 0 0) "
@@ -355,6 +328,10 @@ class LayerOption {
     this.element.classList.add(this.layerControlDeactivatedClass);
     this.setLayerVisibility(false);
   };
+
+  isChecked(){
+    return this.element.querySelector('input[type="checkbox"]').checked
+  }
 
   setLayerVisibility(visible) {
     const visibility = (visible) ? 'visible' : 'none';

--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -4,6 +4,7 @@ import LayerControls from "./LayerControls.js";
 import TiltControl from "./TiltControl.js";
 import { capitalizeFirstLetter } from "./utils.js";
 import { getApiToken, getFreshApiToken } from "./osApiToken.js";
+import {defaultPaintOptions} from "./defaultPaintOptions.js";
 
 export default class MapController {
   constructor(params) {
@@ -168,7 +169,7 @@ export default class MapController {
     this.map.addControl(new CopyrightControl(), 'bottom-right');
 
     const layerControlsList = document.querySelector(`[data-module="layer-controls-${this.mapId}"]`)
-    this.map.addControl(new LayerControls(layerControlsList, this, this.sourceName, this.layers,  this.LayerControlOptions), 'top-right');
+    this.map.addControl(new LayerControls(layerControlsList, this, this.sourceName, this.layers, this.availableLayers, this.LayerControlOptions), 'top-right');
 
 
   }
@@ -315,12 +316,6 @@ export default class MapController {
   }
 
   addVectorTileSource(source) {
-		const defaultPaintOptions = {
-			'fill-color': '#003078',
-			'fill-opacity': 0.6,
-			'weight': 1,
-		};
-
 		// add source
 		this.map.addSource(`${source.name}-source`, {
 			type: 'vector',

--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -163,8 +163,10 @@ export default class MapController {
 
     this.map.addControl(new CopyrightControl(), 'bottom-right');
 
-    if(this.LayerControlOptions.enabled)
-      this.map.addControl(new LayerControls(this, this.sourceName, this.layers, this.availableLayers, this.LayerControlOptions), 'top-right');
+    if(this.LayerControlOptions.enabled){
+      this.layerControlsComponent = new LayerControls(this, this.sourceName, this.layers, this.availableLayers, this.LayerControlOptions);
+      this.map.addControl(this.layerControlsComponent, 'top-right');
+    }
   }
 
   addClickHandlers() {

--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -161,17 +161,10 @@ export default class MapController {
       container: document.getElementById(this.mapId)
     }), 'top-left');
 
-		// // add layer controls
-		// if(this.LayerControlOptions.enabled){
-      // 	this.layerControlsComponent = new LayerControls(layerControlsList, this, this.sourceName, this.layers,  this.LayerControlOptions);
-      // }
-
     this.map.addControl(new CopyrightControl(), 'bottom-right');
 
-    const layerControlsList = document.querySelector(`[data-module="layer-controls-${this.mapId}"]`)
-    this.map.addControl(new LayerControls(layerControlsList, this, this.sourceName, this.layers, this.availableLayers, this.LayerControlOptions), 'top-right');
-
-
+    if(this.LayerControlOptions.enabled)
+      this.map.addControl(new LayerControls(this, this.sourceName, this.layers, this.availableLayers, this.LayerControlOptions), 'top-right');
   }
 
   addClickHandlers() {

--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -38,6 +38,7 @@ export default class MapController {
     this.paint_options = params.paint_options || null;
     this.customStyleJson = '/static/javascripts/OS_VTS_3857_3D.json';
     this.useOAuth2 = params.useOAuth2 || false;
+    this.layers = params.layers || [];
   }
 
   async createMap() {
@@ -159,13 +160,15 @@ export default class MapController {
       container: document.getElementById(this.mapId)
     }), 'top-left');
 
-		// add layer controls
-		if(this.LayerControlOptions.enabled){
-			const layerControlsList = document.querySelector(`[data-module="layer-controls-${this.mapId}"]`)
-			this.layerControlsComponent = new LayerControls(layerControlsList, this, this.sourceName, this.availableLayers,  this.LayerControlOptions);
-		}
+		// // add layer controls
+		// if(this.LayerControlOptions.enabled){
+      // 	this.layerControlsComponent = new LayerControls(layerControlsList, this, this.sourceName, this.layers,  this.LayerControlOptions);
+      // }
 
     this.map.addControl(new CopyrightControl(), 'bottom-right');
+
+    const layerControlsList = document.querySelector(`[data-module="layer-controls-${this.mapId}"]`)
+    this.map.addControl(new LayerControls(layerControlsList, this, this.sourceName, this.layers,  this.LayerControlOptions), 'top-right');
 
 
   }

--- a/assets/javascripts/defaultPaintOptions.js
+++ b/assets/javascripts/defaultPaintOptions.js
@@ -1,0 +1,5 @@
+export const defaultPaintOptions = {
+    'fill-color': '#003078',
+    'fill-opacity': 0.6,
+    'weight': 1,
+};

--- a/assets/stylesheets/component/map/scss/_side-panel.scss
+++ b/assets/stylesheets/component/map/scss/_side-panel.scss
@@ -86,8 +86,8 @@
 
 .dl-map__open-btn {
   z-index: 1002;
-  top: 8px;
-  right: 5px;
+  top: 15px;
+  right: 15px;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='17' viewBox='0 0 18 17'%3E%3Cpath d='M16.215,9.81L18,11L9,17L0,11L1.785,9.81L8.945,14.583C8.978,14.606 9.022,14.606 9.055,14.583L16.215,9.81Z' style='fill:%230b0c0c;'/%3E%3Cpath d='M9,0L0,6L9,12L18,6L9,0ZM9,2.38L14.43,6L9,9.62L3.57,6L9,2.38Z' style='fill:%230b0c0c;'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: 11px 11.5px;

--- a/assets/stylesheets/component/map/scss/_side-panel.scss
+++ b/assets/stylesheets/component/map/scss/_side-panel.scss
@@ -86,8 +86,8 @@
 
 .dl-map__open-btn {
   z-index: 1002;
-  top: 15px;
-  right: 15px;
+  top: 8px;
+  right: 5px;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='17' viewBox='0 0 18 17'%3E%3Cpath d='M16.215,9.81L18,11L9,17L0,11L1.785,9.81L8.945,14.583C8.978,14.606 9.022,14.606 9.055,14.583L16.215,9.81Z' style='fill:%230b0c0c;'/%3E%3Cpath d='M9,0L0,6L9,12L18,6L9,0ZM9,2.38L14.43,6L9,9.62L3.57,6L9,2.38Z' style='fill:%230b0c0c;'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: 11px 11.5px;

--- a/tests/unit/javascript/LayerControl.test.js
+++ b/tests/unit/javascript/LayerControl.test.js
@@ -1,6 +1,7 @@
 import {describe, expect, test, it, beforeEach, vi} from 'vitest'
 
 import LayerControls from '../../../assets/javascripts/LayerControls.js'
+import { LayerOption } from '../../../assets/javascripts/LayerControls.js';
 import {
     getDomElementMock,
     getMapMock,
@@ -11,7 +12,7 @@ import {
     stubGlobalWindow
 } from '../../utils/mockUtils.js';
 
-describe('Layer Control', () => {
+describe('Layer Controls', () => {
     let layerControls;
     const domElementMock = getDomElementMock();
     const mapMock = getMapMock();
@@ -23,24 +24,13 @@ describe('Layer Control', () => {
     beforeEach(() => {
         const module = document.createElement('div');
         layerControls = new LayerControls(module, {map: mapMock}, 'fakeTileSource', ['testLayer1', 'testLayer2'], { layerControlSelector: '[data-layer-control]' });
+        layerControls.$sidePanelContent = domElementMock;
+        layerControls._container = domElementMock;
+        layerControls.$openBtn = domElementMock;
+        layerControls.$closeBtn = domElementMock;
+
         vi.clearAllMocks();
     });
-
-    test('createCloseButton() correctly executes',() => {
-        layerControls.createCloseButton();
-        expect(document.createElement).toHaveBeenCalledWith('button');
-        expect(domElementMock.appendChild).toHaveBeenCalled();
-        expect(domElementMock.addEventListener).toHaveBeenCalled();
-
-    });
-
-    test('createOpenButton() correctly executes',() => {
-        layerControls.createOpenButton();
-        expect(document.createElement).toHaveBeenCalledWith('button');
-        expect(domElementMock.appendChild).toHaveBeenCalled();
-        expect(domElementMock.addEventListener).toHaveBeenCalled();
-
-    })
 
     describe('togglePanel()', () => {
         test('togglePanel() correctly executes when opening',() => {
@@ -61,216 +51,118 @@ describe('Layer Control', () => {
     })
 
     test('toggleLayersBasedOnUrl() correctly executes',() => {
-        layerControls.getEnabledLayerNamesFromUrl = vi.fn().mockImplementation(() => {
-            return ['testLayer1', 'testLayer2']
+        const makeMockLayerOption = (name) => {
+            return {
+                getDatasetName: () => { return name },
+            }
+        }
+        const l1 = makeMockLayerOption('testLayer1');
+        const l2 = makeMockLayerOption('testLayer2');
+        const l3 = makeMockLayerOption('testLayer3');
+
+        layerControls.getEnabledLayersFromUrl = vi.fn().mockImplementation(() => {
+            return [l1, l2]
         })
+        layerControls.layerOptions = [l1,l2,l3];
         layerControls.showEntitiesForLayers = vi.fn();
         layerControls.toggleLayersBasedOnUrl();
-        expect(layerControls.showEntitiesForLayers).toHaveBeenCalledWith(['testLayer1', 'testLayer2']);
+        expect(layerControls.showEntitiesForLayers).toHaveBeenCalledWith([l1, l2]);
     })
 
     test('getEnabledLayerNamesFromUrl() correctly executes',() => {
         stubGlobalUrl([{name: 'layer', value: 'testLayer1'}, {name: 'layer', value: 'testLayer2'}, {name: 'layer', value: 'testLayer3'}, {name: 'layer', value: 'testLayer4'}]);
-        layerControls.datasetNames = ['testLayer1', 'testLayer2', 'testLayer3'];
-        const enabledLayers = layerControls.getEnabledLayerNamesFromUrl();
-        expect(enabledLayers).toEqual(['testLayer1', 'testLayer2', 'testLayer3']);
+        const makeMockLayerOption = (name) => {
+            return {
+                getDatasetName: () => { return name },
+            }
+        }
+        const l1 = makeMockLayerOption('testLayer1');
+        const l2 = makeMockLayerOption('testLayer2');
+        const l3 = makeMockLayerOption('testLayer3');
+
+        layerControls.layerOptions = [l1,l2,l3]
+
+        const enabledLayers = layerControls.getEnabledLayersFromUrl();
+        expect(enabledLayers).toEqual([l1, l2, l3]);
     })
 
     test('showEntitiesForLayers() correctly executes',() => {
         stubGlobalUrl([{name: 'layer', value: 'testLayer1'}, {name: 'layer', value: 'testLayer2'}, {name: 'layer', value: 'testLayer3'}, {name: 'layer', value: 'testLayer4'}]);
-        vi.spyOn(Array.prototype, 'forEach');
-        layerControls.getControlByName = vi.fn().mockImplementation((layerName) => {
-            return `${layerName}-domElement`
-        })
-        layerControls.enable = vi.fn();
-        layerControls.disable = vi.fn();
 
-        layerControls.datasetNames = ['testLayer1', 'testLayer2', 'testLayer3'];
+        const makeMockLayerOption = (name) => {
+            return {
+                getDatasetName: () => { return name },
+                enable: vi.fn(),
+                disable: vi.fn(),
+            }
+        }
 
-        layerControls.showEntitiesForLayers(['testLayer1', 'testLayer2']);
+        const l1 = makeMockLayerOption('testLayer1');
+        const l2 = makeMockLayerOption('testLayer2');
+        const l3 = makeMockLayerOption('testLayer3');
 
-        expect(layerControls.enable).toHaveBeenCalledTimes(2);
-        expect(layerControls.disable).toHaveBeenCalledTimes(1);
+        layerControls.layerOptions = [l1,l2,l3];
+
+        layerControls.showEntitiesForLayers([l1, l2]);
+
+        expect(l1.enable).toHaveBeenCalledTimes(1);
+        expect(l2.enable).toHaveBeenCalledTimes(1);
+        expect(l3.disable).toHaveBeenCalledTimes(1);
     })
 
     test('updateUrl() correctly executes',() => {
         const [urlDeleteMock, urlAppendMock] = stubGlobalUrl();
 
-        layerControls.getDatasetName = vi.fn().mockImplementation((layerName) => {
-            return `${layerName}-domElement`
-        })
-        layerControls.enabledLayers = vi.fn().mockImplementation(() => {
-            return ['testLayer1', 'testLayer2']
-        })
+        layerControls.layerOptions = [
+            {
+                getDatasetName: () => { return 'testLayer1' },
+                isChecked: () => { return true },
+            },
+            {
+                getDatasetName: () => { return 'testLayer2' },
+                isChecked: () => { return true },
+            }
+        ]
+
         layerControls.toggleLayersBasedOnUrl = vi.fn();
         layerControls.updateUrl();
 
         expect(urlDeleteMock).toHaveBeenCalledTimes(1);
         expect(urlDeleteMock).toHaveBeenCalledWith('layer');
         expect(urlAppendMock).toHaveBeenCalledTimes(2);
-        expect(urlAppendMock).toHaveBeenCalledWith('layer','testLayer1-domElement');
-        expect(urlAppendMock).toHaveBeenCalledWith('layer','testLayer2-domElement');
+        expect(urlAppendMock).toHaveBeenCalledWith('layer','testLayer1');
+        expect(urlAppendMock).toHaveBeenCalledWith('layer','testLayer2');
         expect(window.history.pushState).toHaveBeenCalled();
-        expect(window.history.pushState).toHaveBeenCalledWith({}, '', 'http://localhost:3000?layer=testLayer1-domElement&layer=testLayer2-domElementtestHash');
+        expect(window.history.pushState).toHaveBeenCalledWith({}, '', 'http://localhost:3000?layer=testLayer1&layer=testLayer2testHash');
         expect(layerControls.toggleLayersBasedOnUrl).toHaveBeenCalled();
     })
 
-    test('enabledLayers() correctly executes',() => {
-        layerControls.getCheckbox = vi.fn().mockImplementation((layer) => {
-            return { checked: layer == 'testLayer1' }
+    test('filterCheckboxes() correctly executes',() => {
+
+        layerControls.filterCheckboxesArr = vi.fn().mockImplementation(() => {
+            return ['test1', 'test2'];
         });
+        layerControls.displayMatchingCheckboxes = vi.fn();
+        layerControls.filterCheckboxes({target: {value: 'test'}});
 
-        layerControls.$controls = ['testLayer1', 'testLayer2', 'testLayer3'];
+        expect(layerControls.filterCheckboxesArr).toHaveBeenCalledWith('test');
+        expect(layerControls.displayMatchingCheckboxes).toHaveBeenCalledWith(['test1', 'test2']);
 
-        const filteredLayers = layerControls.enabledLayers();
-
-        expect(filteredLayers).toEqual(['testLayer1']);
-    })
-
-    test('disabledLayers() correctly executes',() => {
-        layerControls.getCheckbox = vi.fn().mockImplementation((layer) => {
-            return { checked: layer == 'testLayer1' }
-        });
-
-        layerControls.$controls = ['testLayer1', 'testLayer2', 'testLayer3'];
-
-        const filteredLayers = layerControls.disabledLayers();
-
-        expect(filteredLayers).toEqual(['testLayer2', 'testLayer3']);
-    })
-
-    test('getCheckbox() correctly executes',() => {
-        layerControls.getCheckbox(domElementMock);
-        expect(domElementMock.querySelector).toHaveBeenCalledWith('input[type="checkbox"]');
-    })
-
-    test('getControlByName() correctly executes',() => {
-        layerControls.$controls = [{
-            dataset: {
-                layerControl: 'testLayer1',
-            }
-        },{
-            dataset: {
-                layerControl: 'testLayer2',
-            }
-        },{
-            dataset: {
-                layerControl: 'testLayer3',
-            }
-        }];
-        let control = layerControls.getControlByName('testLayer2');
-        expect(control).toEqual({
-            dataset: {
-                layerControl: 'testLayer2',
-            }
-        });
-    })
-
-    test('enable() correctly executes',() => {
-        layerControls.getDatasetName = vi.fn().mockImplementation((layer) => {
-            return `${layer.dataset.layerControl}`
-        })
-        let domQueriedElementMock = {
-            checked: '',
-        }
-        let domElementMockCopy = {...domElementMock, querySelector: vi.fn().mockImplementation(() => domQueriedElementMock)}
-
-        layerControls.toggleLayerVisibility = vi.fn();
-        layerControls.enable(domElementMockCopy);
-        expect(domElementMockCopy.querySelector).toHaveBeenCalledWith('input[type="checkbox"]');
-        expect(domElementMockCopy.classList.remove).toHaveBeenCalledWith('deactivated-control');
-        expect(layerControls.toggleLayerVisibility).toHaveBeenCalledWith('testLayer1', true);
-        expect(domQueriedElementMock.checked).toBe(true);
-        expect(domElementMockCopy.dataset.layerControlActive).toBe('true');
-    })
-
-    test('disable() correctly executes',() => {
-        layerControls.getDatasetName = vi.fn().mockImplementation((layer) => {
-            return `${layer.dataset.layerControl}`
-        })
-        let domQueriedElementMock = {
-            checked: '',
-        }
-        let domElementMockCopy = {...domElementMock, querySelector: vi.fn().mockImplementation(() => domQueriedElementMock)}
-
-        layerControls.toggleLayerVisibility = vi.fn();
-        layerControls.disable(domElementMockCopy);
-        expect(domElementMockCopy.querySelector).toHaveBeenCalledWith('input[type="checkbox"]');
-        expect(domElementMockCopy.classList.add).toHaveBeenCalledWith('deactivated-control');
-        expect(layerControls.toggleLayerVisibility).toHaveBeenCalledWith('testLayer1', false);
-        expect(domQueriedElementMock.checked).toBe(false);
-        expect(domElementMockCopy.dataset.layerControlActive).toBe('false');
-    })
-
-    test('getDatasetName() correctly executes',() => {
-        let mockElement = {
-            dataset: {
-                layerControl: 'testLayer1',
-            }
-        };
-        let datasetName = layerControls.getDatasetName(mockElement);
-        expect(datasetName).toBe('testLayer1');
-    })
-
-    describe('toggleLayerVisibility()', () => {
-
-        test('correctly executes when making visible',() => {
-            layerControls.mapController.setLayerVisibility = vi.fn();
-            layerControls.availableLayers = { testLayer1: ['testLayer1-1', 'testLayer1-2'], unselected: ['unselected-1', 'unselected-2'] };
-            layerControls.toggleLayerVisibility('testLayer1', true);
-            expect(layerControls.mapController.setLayerVisibility).toHaveBeenCalledWith('testLayer1-1', 'visible');
-            expect(layerControls.mapController.setLayerVisibility).toHaveBeenCalledWith('testLayer1-2', 'visible');
-            expect(layerControls.mapController.setLayerVisibility).not.toHaveBeenCalledWith('unselected-1', 'visible');
-            expect(layerControls.mapController.setLayerVisibility).not.toHaveBeenCalledWith('unselected-2', 'visible');
-        })
-
-        test('correctly executes when making invisible',() => {
-            layerControls.mapController.setLayerVisibility = vi.fn();
-            layerControls.availableLayers = { testLayer1: ['testLayer1-1', 'testLayer1-2'], unselected: ['unselected-1', 'unselected-2'] };
-            layerControls.toggleLayerVisibility('testLayer1', false);
-            expect(layerControls.mapController.setLayerVisibility).toHaveBeenCalledWith('testLayer1-1', 'none');
-            expect(layerControls.mapController.setLayerVisibility).toHaveBeenCalledWith('testLayer1-2', 'none');
-            expect(layerControls.mapController.setLayerVisibility).not.toHaveBeenCalledWith('unselected-1', 'none');
-            expect(layerControls.mapController.setLayerVisibility).not.toHaveBeenCalledWith('unselected-2', 'none');
-        })
-    })
-
-
-    test('onControlChkbxChange() correctly executes',() => {
-        layerControls.updateUrl = vi.fn();
-        layerControls.onControlChkbxChange({ target: { dataset: { layerControl: 'testLayer1' } } });
-        expect(layerControls.updateUrl).toHaveBeenCalledTimes(1);
-    })
-
-    test('getClickableLayers() correctly executes',() => {
-        layerControls.enabledLayers = vi.fn().mockImplementation(() => {
-            return ['testLayer1', 'testLayer2']
-        })
-        layerControls.getDatasetName = vi.fn().mockImplementation((layer) => {
-            return layer
-        })
-        layerControls.availableLayers = { testLayer1: ['testLayer1-1', 'testLayer1-2'], testLayer2: ['testLayer2-1', 'testLayer2Fill'] };
-        let clickableLayers = layerControls.getClickableLayers();
-
-        expect(clickableLayers).toEqual(['testLayer1-1', 'testLayer2Fill']);
     })
 
     test('filterCheckboxesArray() correctly executes',() => {
-        const generateCheckboxWithName = (name) => {
+        const generateLayerControlWithName = (name) => {
             return {
-                querySelector: vi.fn().mockImplementation(() => {
-                    return {
-                        textContent: name,
-                    }
-                })
+                textContent: name,
+                getDatasetName: () => { return name }
             }
         }
 
-        const BrownfieldLandCheckbox = generateCheckboxWithName('Brownfield-land');
-        const GreenBeltCheckbox = generateCheckboxWithName('Green-belt');
-        const TreeCheckbox = generateCheckboxWithName('Tree');
+        const BrownfieldLandCheckbox = generateLayerControlWithName('Brownfield-land');
+        const GreenBeltCheckbox = generateLayerControlWithName('Green-belt');
+        const TreeCheckbox = generateLayerControlWithName('Tree');
 
-        layerControls.checkboxArr = [
+        layerControls.layerOptions = [
             BrownfieldLandCheckbox,
             GreenBeltCheckbox,
             TreeCheckbox
@@ -290,28 +182,215 @@ describe('Layer Control', () => {
     })
 
     test('displayMatchingCheckboxes() correctly executes',() => {
-        const generateCheckboxWithName = (name) => {
+        const generateLayerOption = (name) => {
             return {
                 style: {
                     display: '',
                 },
+                setLayerCheckboxVisibility: vi.fn(),
             }
         }
 
-        const BrownfieldLandCheckbox = generateCheckboxWithName('Brownfield-land');
-        const GreenBeltCheckbox = generateCheckboxWithName('Green-belt');
-        const TreeCheckbox = generateCheckboxWithName('Tree');
+        const BrownfieldLandCheckbox = generateLayerOption('Brownfield-land');
+        const GreenBeltCheckbox = generateLayerOption('Green-belt');
+        const TreeCheckbox = generateLayerOption('Tree');
 
-        layerControls.checkboxArr = [
+        layerControls.layerOptions = [
             BrownfieldLandCheckbox,
             GreenBeltCheckbox,
             TreeCheckbox
         ]
 
         layerControls.displayMatchingCheckboxes([BrownfieldLandCheckbox, GreenBeltCheckbox]);
-        expect(BrownfieldLandCheckbox.style.display).toBe('block');
-        expect(GreenBeltCheckbox.style.display).toBe('block');
-        expect(TreeCheckbox.style.display).toBe('none');
+        expect(BrownfieldLandCheckbox.setLayerCheckboxVisibility).toHaveBeenCalledWith(true);
+        expect(GreenBeltCheckbox.setLayerCheckboxVisibility).toHaveBeenCalledWith(true);
+        expect(TreeCheckbox.setLayerCheckboxVisibility).toHaveBeenCalledWith(false);
 
     })
+
+    describe('layer option', () => {
+        test('makeElement() correctly executes',() => {
+            LayerOption.prototype.makeLayerSymbol = vi.fn().mockImplementation(() => { return '' });
+            const option = new LayerOption('testLayer1', ['testLayer1-1', 'testLayer1-2'], undefined);
+            expect(option.element).toEqual(domElementMock);
+        })
+
+        describe('makeLayerSymbol()', () => {
+            test('correctly executes when type is fill',() => {
+                const layerOptionMock = {
+                    paint_options: {
+                        type: 'fill',
+                        opacity: 0.5,
+                        colour: '#AABBCC',
+                    },
+                    dataset: 'testLayer1',
+                }
+
+                const result = LayerOption.prototype.makeLayerSymbol(layerOptionMock);
+
+                expect(result).toContain('border-color: #AABBCC;')
+                expect(result).toContain('background: #AABBCC7f')
+                expect(result).toContain('testLayer1')
+            })
+
+            test('correctly executes when type is point',() => {
+                const layerOptionMock = {
+                    paint_options: {
+                        type: 'point',
+                        opacity: 0.5,
+                        colour: '#AABBCC',
+                    },
+                    dataset: 'testLayer1',
+                }
+
+                const result = LayerOption.prototype.makeLayerSymbol(layerOptionMock);
+
+                expect(result).toContain('fill: #AABBCC;')
+                expect(result).toContain('opacity: 0.5;')
+                expect(result).toContain('testLayer1')
+            })
+        })
+
+        test('enable() correctly executes',() => {
+
+            const mockCheckbox = {...domElementMock, checked: false}
+
+            LayerOption.prototype.makeElement = vi.fn()
+            .mockImplementation(() => {
+                return {
+                    ...domElementMock,
+                    dataset: {layerControlActive: 'false'},
+                    querySelector: () => {
+                        return mockCheckbox;
+                    }
+                };
+            })
+
+            const option = new LayerOption('testLayer1', ['testLayer1-1', 'testLayer1-2'], undefined);
+
+            option.setLayerVisibility = vi.fn();
+            option.enable();
+            expect(option.element.dataset.layerControlActive).toEqual('true');
+            expect(mockCheckbox.checked).toBe(true);
+            expect(option.setLayerVisibility).toHaveBeenCalledWith(true);
+        })
+
+        test('disable() correctly executes',() => {
+
+            const mockCheckbox = {...domElementMock, checked: true}
+
+            LayerOption.prototype.makeElement = vi.fn().mockImplementation(() => {
+                return {
+                    ...domElementMock,
+                    dataset: {layerControlActive: 'true'},
+                    querySelector: () => {
+                        return mockCheckbox;
+                    }
+                };
+            })
+
+            const option = new LayerOption('testLayer1', ['testLayer1-1', 'testLayer1-2'], undefined);
+
+            option.setLayerVisibility = vi.fn();
+            option.disable();
+            expect(option.element.dataset.layerControlActive).toEqual('false');
+            expect(mockCheckbox.checked).toBe(false);
+            expect(option.setLayerVisibility).toHaveBeenCalledWith(false);
+        })
+
+        test('getDatasetName() correctly executes',() => {
+            LayerOption.prototype.makeElement = vi.fn();
+            const option = new LayerOption({dataset: 'testLayer1'}, ['testLayer1-1', 'testLayer1-2'], undefined);
+            let datasetName = option.getDatasetName();
+            expect(datasetName).toBe('testLayer1');
+        })
+
+        describe('setLayerVisibility()', () => {
+            test('correctly executes when making visible',() => {
+                LayerOption.prototype.makeElement = vi.fn();
+                const option = new LayerOption({dataset: 'testLayer1'}, ['testLayer1-1', 'testLayer1-2'], undefined);
+
+                option.layerControls = {
+                    mapController: {
+                        setLayerVisibility: vi.fn(),
+                    }
+                }
+                option.setLayerVisibility(true);
+
+                expect(option.layerControls.mapController.setLayerVisibility).toHaveBeenCalledWith('testLayer1-1', 'visible');
+                expect(option.layerControls.mapController.setLayerVisibility).toHaveBeenCalledWith('testLayer1-2', 'visible');
+            })
+
+            test('correctly executes when making invisible',() => {
+                LayerOption.prototype.makeElement = vi.fn();
+                const option = new LayerOption({dataset: 'testLayer1'}, ['testLayer1-1', 'testLayer1-2'], undefined);
+
+                option.layerControls = {
+                    mapController: {
+                        setLayerVisibility: vi.fn(),
+                    }
+                }
+                option.setLayerVisibility(false);
+
+                expect(option.layerControls.mapController.setLayerVisibility).toHaveBeenCalledWith('testLayer1-1', 'none');
+                expect(option.layerControls.mapController.setLayerVisibility).toHaveBeenCalledWith('testLayer1-2', 'none');
+            })
+        })
+
+        describe('setLayerCheckboxVisibility()', () => {
+            test('correctly executes when making visible',() => {
+                LayerOption.prototype.makeElement = vi.fn().mockImplementation(() => domElementMock);
+                const option = new LayerOption({dataset: 'testLayer1'}, ['testLayer1-1', 'testLayer1-2'], undefined);
+
+                option.setLayerCheckboxVisibility(true);
+
+                expect(domElementMock.style.display).toEqual('block');
+            })
+
+            test('correctly executes when making invisible',() => {
+                LayerOption.prototype.makeElement = vi.fn().mockImplementation(() => domElementMock);
+                const option = new LayerOption({dataset: 'testLayer1'}, ['testLayer1-1', 'testLayer1-2'], undefined);
+
+                option.setLayerCheckboxVisibility(false);
+
+                expect(domElementMock.style.display).toEqual('none');
+            })
+        })
+
+        describe('isChecked', () => {
+            test('correctly executes when checked',() => {
+                const mockCheckbox = {...domElementMock, checked: true}
+                LayerOption.prototype.makeElement = vi.fn().mockImplementation(() => {
+                    return {
+                        ...domElementMock,
+                        dataset: {layerControlActive: 'false'},
+                        querySelector: () => {
+                            return mockCheckbox;
+                        }
+                    };
+                })
+                const option = new LayerOption({dataset: 'testLayer1'}, ['testLayer1-1', 'testLayer1-2'], undefined);
+                const result = option.isChecked();
+                expect(result).toBe(true);
+            })
+
+            test('correctly executes when not checked',() => {
+                const mockCheckbox = {...domElementMock, checked: false}
+                LayerOption.prototype.makeElement = vi.fn().mockImplementation(() => {
+                    return {
+                        ...domElementMock,
+                        dataset: {layerControlActive: 'false'},
+                        querySelector: () => {
+                            return mockCheckbox;
+                        }
+                    };
+                })
+                const option = new LayerOption({dataset: 'testLayer1'}, ['testLayer1-1', 'testLayer1-2'], undefined);
+                const result = option.isChecked();
+                expect(result).toBe(false);
+            })
+        })
+
+    })
+
 })

--- a/tests/unit/javascript/LayerControl.test.js
+++ b/tests/unit/javascript/LayerControl.test.js
@@ -208,6 +208,23 @@ describe('Layer Controls', () => {
 
     })
 
+    test('getClickableLayers() correctly executes',() => {
+        layerControls.enabledLayers = vi.fn().mockImplementation(() => {
+            return [
+                {
+                    getDatasetName: () => 'testLayer1',
+                },
+                {
+                    getDatasetName: () => 'testLayer2'
+                },
+            ]
+        })
+        layerControls.availableLayers = { testLayer1: ['testLayer1-1', 'testLayer1-2'], testLayer2: ['testLayer2-1', 'testLayer2Fill'] };
+        let clickableLayers = layerControls.getClickableLayers();
+
+        expect(clickableLayers).toEqual(['testLayer1-1', 'testLayer2Fill']);
+    })
+
     describe('layer option', () => {
         test('makeElement() correctly executes',() => {
             let spy = vi.spyOn(LayerOption.prototype, 'makeLayerSymbol').mockImplementation(() => { return ''});

--- a/tests/unit/javascript/LayerControl.test.js
+++ b/tests/unit/javascript/LayerControl.test.js
@@ -210,9 +210,10 @@ describe('Layer Controls', () => {
 
     describe('layer option', () => {
         test('makeElement() correctly executes',() => {
-            LayerOption.prototype.makeLayerSymbol = vi.fn().mockImplementation(() => { return '' });
+            let spy = vi.spyOn(LayerOption.prototype, 'makeLayerSymbol').mockImplementation(() => { return ''});
             const option = new LayerOption('testLayer1', ['testLayer1-1', 'testLayer1-2'], undefined);
             expect(option.element).toEqual(domElementMock);
+            spy.mockRestore();
         })
 
         describe('makeLayerSymbol()', () => {

--- a/tests/utils/mockUtils.js
+++ b/tests/utils/mockUtils.js
@@ -55,6 +55,7 @@ const mapMock = {
             })
         }
     }),
+    moveLayer: vi.fn(),
 };
 
 const mapControllerMock = {


### PR DESCRIPTION
Ticket: https://trello.com/c/TQNpHx0L/430-national-map-layers-components-not-showing-up-in-full-screen

The layerControls panel isn't a proper maplibre component. so when full screening the map the component disappears
We should change this to be an official maplibre component 

![image](https://github.com/digital-land/digital-land.info/assets/15090285/48449520-930b-49b0-99c6-f911ee51b80e)

## Key changes made
- converted the layer controls map overlay to be a maplibre component. (by using the interface methods onAdd/onRemove)
- rewrote tests to work with new code

## Additional changes made
- removed the #monitoring sting from the end of the link on the guidance page 
- added a mock function to the maplibre mock object for moving layers to tidy up the test console of error messages
- moved default paint options into its own file to be reused

## Further changes to make
- We should look at making the layer controls component more accessible
- - this could be done as part of a new ticket. or even as part of the accessibility work that is currently ongoing

