### PR TITLE
Fix/map controls

### DIFF
--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -411,7 +411,7 @@ export default class MapController {
   createFeaturesPopup(features) {
     const wrapper = document.createElement('div');
     wrapper.classList.add('app-popup');
-    wrapper.onwheel = makePreventScrollFn('.app-popup-list');
+    wrapper.onwheel = makePreventScrollFn(['.app-popup-list']);
 
     const featureOrFeatures = features.length > 1 ? 'features' : 'feature';
     const heading = document.createElement('h3');

--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -2,7 +2,7 @@ import BrandImageControl from "./BrandImageControl.js";
 import CopyrightControl from "./CopyrightControl.js";
 import LayerControls from "./LayerControls.js";
 import TiltControl from "./TiltControl.js";
-import { capitalizeFirstLetter, makePreventScrollFn } from "./utils.js";
+import { capitalizeFirstLetter, preventScroll } from "./utils.js";
 import { getApiToken, getFreshApiToken } from "./osApiToken.js";
 import {defaultPaintOptions} from "./defaultPaintOptions.js";
 
@@ -196,7 +196,7 @@ export default class MapController {
   overwriteWheelEventsForControls() {
     const mapEl = document.getElementById(this.mapId)
     const mapControlsArray = mapEl.querySelectorAll('.maplibregl-control-container')
-    mapControlsArray.forEach((mapControls) => mapControls.addEventListener('wheel', makePreventScrollFn(['.dl-map__side-panel__content']), {passive: false}));
+    mapControlsArray.forEach((mapControls) => mapControls.addEventListener('wheel', preventScroll(['.dl-map__side-panel__content']), {passive: false}));
   }
 
   addClickHandlers() {
@@ -447,7 +447,7 @@ export default class MapController {
   createFeaturesPopup(features) {
     const wrapper = document.createElement('div');
     wrapper.classList.add('app-popup');
-    wrapper.onwheel = makePreventScrollFn(['.app-popup-list']);
+    wrapper.onwheel = preventScroll(['.app-popup-list']);
 
     const featureOrFeatures = features.length > 1 ? 'features' : 'feature';
     const heading = document.createElement('h3');

--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -2,7 +2,7 @@ import BrandImageControl from "./BrandImageControl.js";
 import CopyrightControl from "./CopyrightControl.js";
 import LayerControls from "./LayerControls.js";
 import TiltControl from "./TiltControl.js";
-import { capitalizeFirstLetter } from "./utils.js";
+import { capitalizeFirstLetter, makePreventScrollFn } from "./utils.js";
 import { getApiToken, getFreshApiToken } from "./osApiToken.js";
 import {defaultPaintOptions} from "./defaultPaintOptions.js";
 
@@ -95,6 +95,7 @@ export default class MapController {
     }
     this.addControls()
     this.addClickHandlers();
+    this.overwriteWheelEventsForControls();
   };
 
   loadImages(imageSrc=[]) {
@@ -167,6 +168,12 @@ export default class MapController {
       this.layerControlsComponent = new LayerControls(this, this.sourceName, this.layers, this.availableLayers, this.LayerControlOptions);
       this.map.addControl(this.layerControlsComponent, 'top-right');
     }
+  }
+
+  overwriteWheelEventsForControls() {
+    const mapEl = document.getElementById(this.mapId)
+    const mapControlsArray = mapEl.querySelectorAll('.maplibregl-control-container')
+    mapControlsArray.forEach((mapControls) => mapControls.addEventListener('wheel', makePreventScrollFn(['.dl-map__side-panel__content']), {passive: false}));
   }
 
   addClickHandlers() {
@@ -404,18 +411,7 @@ export default class MapController {
   createFeaturesPopup(features) {
     const wrapper = document.createElement('div');
     wrapper.classList.add('app-popup');
-    wrapper.onwheel = (e) => {
-      let list = e.target.closest('.app-popup-list');
-
-      if(!list){
-        e.preventDefault();
-        return
-      }
-
-      var verticalScroll = list.scrollHeight > list.clientHeight;
-      if(!verticalScroll)
-        e.preventDefault();
-    };
+    wrapper.onwheel = makePreventScrollFn('.app-popup-list');
 
     const featureOrFeatures = features.length > 1 ? 'features' : 'feature';
     const heading = document.createElement('h3');

--- a/assets/javascripts/utils.js
+++ b/assets/javascripts/utils.js
@@ -31,7 +31,7 @@ export const convertNodeListToArray = (nl) => {
 // Prevents scrolling of the page when the user triggers the wheel event on a div
 // while still allowing scrolling of any specified scrollable child elements.
 // Params:
-//  scrollableDivs: an array of class names of potential scrollable elements
+//  scrollableChildElements: an array of class names of potential scrollable elements
 export const preventScroll = (scrollableChildElements = []) => {
   return (e) => {
     const closestClassName = scrollableChildElements.find((c) => {

--- a/assets/javascripts/utils.js
+++ b/assets/javascripts/utils.js
@@ -27,3 +27,29 @@ export const capitalizeFirstLetter = (string) => {
 export const convertNodeListToArray = (nl) => {
   return Array.prototype.slice.call(nl)
 }
+
+export const makePreventScrollFn = (scrollDivClass = []) => {
+  return (e) => {
+    const closestClassName = scrollDivClass.find((c) => {
+      return e.target.closest(c) != null;
+    });
+
+    if(!closestClassName){
+      e.preventDefault();
+      return false
+    }
+
+    const list = e.target.closest(closestClassName);
+
+    if(!list){
+      e.preventDefault();
+      return false
+    }
+
+    var verticalScroll = list.scrollHeight > list.clientHeight;
+    if(!verticalScroll)
+      e.preventDefault();
+
+    return false;
+  }
+}

--- a/assets/javascripts/utils.js
+++ b/assets/javascripts/utils.js
@@ -28,9 +28,13 @@ export const convertNodeListToArray = (nl) => {
   return Array.prototype.slice.call(nl)
 }
 
-export const makePreventScrollFn = (scrollDivClass = []) => {
+// Prevents scrolling of the page when the user triggers the wheel event on a div
+// while still allowing scrolling of any specified scrollable child elements.
+// Params:
+//  scrollableDivs: an array of class names of potential scrollable elements
+export const preventScroll = (scrollableChildElements = []) => {
   return (e) => {
-    const closestClassName = scrollDivClass.find((c) => {
+    const closestClassName = scrollableChildElements.find((c) => {
       return e.target.closest(c) != null;
     });
 

--- a/assets/stylesheets/component/map/scss/_side-panel.scss
+++ b/assets/stylesheets/component/map/scss/_side-panel.scss
@@ -6,16 +6,8 @@
   right: $govuk-gutter-half;
   background: govuk-colour("white");
   box-shadow: 0 0 3px rgba(govuk-colour("black"), .8);
-
-  @include govuk-media-query($until: tablet) {
-    top: 10px;
-    right: 10px;
-    left: 10px;
-  }
-
-  @include govuk-media-query($from: tablet) {
-    width: 330px;
-  }
+  width: 330px;
+  max-width: calc(100vw - 130px);
 }
 
 .dl-map__side-panel--full {

--- a/changeLog.md
+++ b/changeLog.md
@@ -14,6 +14,16 @@
 # ChangeLog
 <br>
 
+## 14-09-2023
+### What's new
+- Updated layer controls css so it correctly displays on smaller screens
+- overwrite scroll event for map popups/controls to prevent page scrolling
+### Why was this change made?
+- The layer controls would disappear on smaller screens
+- The scroll event listener would cause the page to scroll when zooming on a map popup/control
+***
+<br />
+
 ## 13-09-2023
 ### What's new
 - Back button now simulates window history back


### PR DESCRIPTION
Tickets:
 - https://trello.com/c/elqebQto/476-fix-layercontrols-component-disappearing-on-small-screens
 - https://trello.com/c/d8flg5xI/468-ensure-all-the-controls-on-the-map-dont-cause-a-scroll-action-when-scrolling-on-them 

### What's new
- Updated layer controls css so it correctly displays on smaller screens
- overwrite scroll event for map popups/controls to prevent page scrolling
### Why was this change made?
- The layer controls would disappear on smaller screens
- The scroll event listener would cause the page to scroll when zooming on a map popup/control
***