### PR TITLE
updated changelog

### DIFF
--- a/changeLog.md
+++ b/changeLog.md
@@ -14,6 +14,20 @@
 # ChangeLog
 <br>
 
+## 15-09-2023
+### What's new
+- Updated circle radius on the map to interpolate between 8 and 0.8 based on zoom level
+- Feature layers on the map now have a cursor pointer when hovered over
+- OS copyright updated to specify Basemap contains OS data &copy; Crown copyright and database rights
+- Zoom and centre now gets added to the url for the map, and when navigating back to the map page the map will be zoomed and centred to the previous location
+### Why was this change made?
+- Smaller circles on the map are easier to see
+- The cursor pointer makes it more obvious that the feature is clickable
+- To avoid people thinking that our data is owned by OS
+- To make it easier to share a specific location on the map
+***
+<br />
+
 ## 13-09-2023
 ### What's new
 - Back button now simulates window history back


### PR DESCRIPTION
added the following entry to the changelog

## 15-09-2023
### What's new
- Updated circle radius on the map to interpolate between 8 and 0.8 based on zoom level
- Feature layers on the map now have a cursor pointer when hovered over
- OS copyright updated to specify Basemap contains OS data &copy; Crown copyright and database rights
- Zoom and centre now gets added to the url for the map, and when navigating back to the map page the map will be zoomed and centred to the previous location
### Why was this change made?
- Smaller circles on the map are easier to see
- The cursor pointer makes it more obvious that the feature is clickable
- To avoid people thinking that our data is owned by OS
- To make it easier to share a specific location on the map
***
<br />