### PR TITLE
hover pointer now remains when leaving a polygon inside a polygon

### DIFF
--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -40,6 +40,7 @@ export default class MapController {
     this.customStyleJson = '/static/javascripts/OS_VTS_3857_3D.json';
     this.useOAuth2 = params.useOAuth2 || false;
     this.layers = params.layers || [];
+    this.featuresHoveringOver = 0;
   }
 
   getViewFromUrl() {
@@ -234,9 +235,14 @@ export default class MapController {
     if(['fill', 'fill-extrusion', 'circle'].includes(layerType)){
       this.map.on('mouseover', layerName, () => {
         this.map.getCanvas().style.cursor = 'pointer'
+        this.featuresHoveringOver++;
+        console.log(this.featuresHoveringOver)
       })
       this.map.on('mouseout', layerName, () => {
-        this.map.getCanvas().style.cursor = ''
+        this.featuresHoveringOver--;
+        console.log(this.featuresHoveringOver)
+        if(this.featuresHoveringOver == 0)
+          this.map.getCanvas().style.cursor = ''
       })
     }
 


### PR DESCRIPTION
ticket: https://trello.com/c/mMTRDtJF/494-bug-cursor-changed-from-pointer-to-grab-when-you-mouseout-of-a-feature-that-is-contained-in-another-feature

https://github.com/digital-land/digital-land.info/assets/15090285/50c139f8-f66f-4d1e-83be-01b55bd029e9



