### PR TITLE
whole of england now shown by default up to 4k

### DIFF
--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -63,15 +63,15 @@ export default class MapController {
 
     var map = new maplibregl.Map({
       container: this.mapId,
-      minZoom: 4,
+      minZoom: 5.5,
       maxZoom: 18,
       style: this.customStyleJson,
       maxBounds: [
-        [ -11, 49 ],
-        [ 8, 57 ]
+        [ -15, 49 ],
+        [ 13, 57 ]
       ],
-      center: viewFromUrl.centre || [ -1.5, 53.1 ],
-      zoom: viewFromUrl.zoom || 4,
+      center: viewFromUrl.centre || [ -1, 52.9 ],
+      zoom: viewFromUrl.zoom || 5.5,
       transformRequest: (url, resourceType) => {
         if(url.indexOf('api.os.uk') > -1){
           if(! /[?&]key=/.test(url) ) url += '?key=null'


### PR DESCRIPTION
https://trello.com/c/iFEbQKfH/478-minimum-zoom-should-show-all-of-england-including-on-large-screens-ie-4k

### What's new
- Changed the default viewport and zoom level of the map to make sure all of england is visible (tested on screen sizes up to 4k)
### Why was this change made?
- We want to ensure all of england is visible on the map

# Before:
![image](https://github.com/digital-land/digital-land.info/assets/15090285/59af0297-364e-4821-87e8-75427744f2ac)

# After
![image](https://github.com/digital-land/digital-land.info/assets/15090285/88c1dbfc-b421-4766-a387-891fe888a81b)

# Further Work
- we should look at getting the European continent on the map, as the os map only shows some of the coastline
