### PR TITLE
Chore/nav guidance for publishers

### DIFF
--- a/application/templates/partials/footer.html
+++ b/application/templates/partials/footer.html
@@ -5,7 +5,6 @@
         "items": [
             {"href": "/service-status", "text": "Service status"},
             {"href": "/about/roadmap", "text": "Roadmap"},
-            {"href": "/guidance", "text": "Guidance for publishers"},
             {"href": "/accessibility-statement", "text": "Accessibility statement"},
         ],
         "html": 'Built by the <a href="https://www.gov.uk/government/organisations/department-for-levelling-up-housing-and-communities" class="govuk-footer__link">Department for Levelling Up, Housing and Communities</a>',

--- a/application/templates/partials/mast-head.html
+++ b/application/templates/partials/mast-head.html
@@ -25,6 +25,10 @@
         {
             "href": "/docs",
             "text": "Documentation"
-        }
+        },
+        {
+            "href": "/guidance",
+            "text": "Guidance for publishers"
+        },
     ]
 }) }}

--- a/changeLog.md
+++ b/changeLog.md
@@ -14,6 +14,12 @@
 # ChangeLog
 <br>
 
+## 22-09-2023
+### What's new
+- Moved the guidance for publishers link from the footer to the top nav
+### Why was this change made?
+- To make it easier for publishers to find the guidance
+
 ## 15-09-2023
 ### What's new
 - Updated layer controls css so it correctly displays on smaller screens


### PR DESCRIPTION
### What's new
- Moved the guidance for publishers link from the footer to the top nav
### Why was this change made?
- To make it easier for publishers to find the guidance

Ticket: 
https://trello.com/c/KnTvfyR3/504-move-guidance-for-publishers-link-to-top-nav

![image](https://github.com/digital-land/digital-land.info/assets/15090285/1b3e68e9-cabe-4cb9-88e9-e3bf1c95c351)
