### PR TITLE
updated the title of the map to 'Map of planning data for England'

### DIFF
--- a/application/templates/homepage.html
+++ b/application/templates/homepage.html
@@ -68,7 +68,7 @@
           },
           'link': {
             'href': '/map/',
-            'text': 'Explore the national map of planning'
+            'text': 'Explore the map of planning data for England'
           },
         })
       }}

--- a/application/templates/national-map.html
+++ b/application/templates/national-map.html
@@ -7,7 +7,7 @@
 {% set fullWidthHeader = true %}
 
 {% set includesMap = true %}
-{% block pageTitle %}National map of planning data | Planning Data{% endblock %}
+{% block pageTitle %}Map of planning data for England | Planning Data{% endblock %}
 
 {%
   set notePanel = '<p>Find, understand and download the <a href="/dataset" class="govuk-link">datasets used to create this map</a>.</p>'
@@ -29,11 +29,11 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">National map of planning data</h1>
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Map of planning data for England</h1>
     </div>
   </div>
 
-  <p id="aria-label-national-map" class="govuk-body-l">National map of the planning data collected and collated by Planning Data.</p>
+  <p id="aria-label-national-map" class="govuk-body-l">See the data we've collected and collated on a map.</p>
 
   {{
     map({

--- a/application/templates/pages/accessibility-statement.md
+++ b/application/templates/pages/accessibility-statement.md
@@ -38,23 +38,23 @@ Some pages need heading levels and reading order adjusted to make comprehension 
 
 #### 1.3.3: Sensory Characteristics
 
-National Map of planning data currently relies on the ability to see shapes, colours and visual locations. A 'non map alternative' is required for users unable able perceive content visually.
+Map of planning data for England currently relies on the ability to see shapes, colours and visual locations. A 'non map alternative' is required for users unable able perceive content visually.
 
 #### 1.4.1: Use of Color
 
-The National Map of Planning Data currently relies on colour to distinguish geographic shapes from one dataset to another.
+The map of planning data for England currently relies on colour to distinguish geographic shapes from one dataset to another.
 
 #### 1.4.3: Contrast (Minimum)
 
-The National Map of Planning Data fails colour contrast for map features and data layers. Text labels for locations can become difficult to read and are not a contrast ratio of at least 4.5:1.
+The map of planning data for England fails colour contrast for map features and data layers. Text labels for locations can become difficult to read and are not a contrast ratio of at least 4.5:1.
 
 #### 1.4.11: Non-text Contrast
 
-The National Map of Planning has shapes and areas of colour that when overlayed do not have sufficient contrast.
+The map of planning data for England has shapes and areas of colour that when overlayed do not have sufficient contrast.
 
 #### 2.1.1: Keyboard
 
-Features of the National Map of Planning Data are not able to be access via a keyboard.
+Features of the map of planning data for England are not able to be access via a keyboard.
 
 #### 3.2.2: On Input
 

--- a/changeLog.md
+++ b/changeLog.md
@@ -16,6 +16,12 @@
 
 ## 22-09-2023
 ### What's new
+- Updated the title for the map to 'Map of planning data for England'
+### Why was this change made?
+- To make it clear that the map is only for England
+
+## 22-09-2023
+### What's new
 - Moved the guidance for publishers link from the footer to the top nav
 ### Why was this change made?
 - To make it easier for publishers to find the guidance

--- a/tests/acceptance/test_acceptance.py
+++ b/tests/acceptance/test_acceptance.py
@@ -50,7 +50,7 @@ def test_acceptance(server_process, page, test_data):
 
     page.click("text=Map")
     assert page.url == f"{BASE_URL}/map/"
-    assert page.text_content("h1") == "National map of planning data"
+    assert page.text_content("h1") == "Map of planning data for England"
     page.goto(BASE_URL)
 
     page.click("text=Search")


### PR DESCRIPTION
### What's new
- Updated the title for the map to 'Map of planning data for England'
### Why was this change made?
- To make it clear that the map is only for England

### Ticket: 
- https://trello.com/c/HFknCyRA/439-make-it-apparent-where-the-site-is-for-national-map-isnt-clear

![image](https://github.com/digital-land/digital-land.info/assets/15090285/ccbce707-29ab-4410-b11f-23b7a2b47eee)
