### PR TITLE
increase the opacity of the wales obscure layer

### DIFF
--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -162,7 +162,7 @@ export default class MapController {
 	}
 
   obscureWales(){
-    this.obscure('Wales_simplified');
+    this.obscure('Wales_simplified', '#FFFFFF', 0.4);
   }
 
   obscureScotland(){

--- a/changeLog.md
+++ b/changeLog.md
@@ -14,6 +14,12 @@
 # ChangeLog
 <br>
 
+## 29-09-2023
+### What's new
+- increase wales obscure opacity
+### Why was this change made?
+- Some data we have is on wales, so we need to obscure it less
+
 ## 26-09-2023
 ### What's new
 - Updated the base-tile set style changing min and max zoom levels for layers


### PR DESCRIPTION
### What's new
- increase wales obscure opacity
### Why was this change made?
- Some data we have is on wales, so we need to obscure it less

![image](https://github.com/digital-land/digital-land.info/assets/15090285/e123f8a5-789a-482a-9d3a-8b48397ebc0d)
![image](https://github.com/digital-land/digital-land.info/assets/15090285/e008d290-37fd-4205-9bc7-cb85036adfa6)
