### PR TITLE
Test/navigate to a dataset specification

### DIFF
--- a/application/templates/components/entity-card/macro.jinja
+++ b/application/templates/components/entity-card/macro.jinja
@@ -6,7 +6,7 @@
     {% set propertiesArr = [
             { "key": "Dataset", "value": e["dataset"] },
             { "key": "Reference", "value": e["reference"] },
-            { "key": "period", "value": e['end-date'] | convert_to_current_or_historical  },
+            { "key": "Period", "value": e['end-date'] | convert_to_current_or_historical  },
         ]
     %}
 

--- a/changeLog.md
+++ b/changeLog.md
@@ -17,6 +17,8 @@
 ## 10-10-2023
 ### What's new
 - Added an acceptance test that tests navigation to a dataset page
+### Why was this change made?
+- because this user journey was documented as part of a recent group session we did
 
 ## 09-10-2023
 ### What's new

--- a/changeLog.md
+++ b/changeLog.md
@@ -14,6 +14,10 @@
 # ChangeLog
 <br>
 
+## 10-10-2023
+### What's new
+- Added an acceptance test that tests navigation to a dataset page
+
 ## 09-10-2023
 ### What's new
 - Added tests to ensure each and every page request returns a successful response

--- a/tests/acceptance/test_dataset.py
+++ b/tests/acceptance/test_dataset.py
@@ -45,6 +45,22 @@ def test_download_data_for_dataset(
     assert ".geojson" in geojson_href
 
 
+def test_navigate_to_a_dataset_specification(
+    server_process, BASE_URL, page, add_base_entities_to_database_yield_reset
+):
+    page.goto(BASE_URL)
+    page.get_by_role("link", name="Datasets", exact=True).click()
+    page.get_by_role("link", name="Geography").click()
+    with page.expect_navigation() as response:
+        page.get_by_role("link", name="Brownfield site").click()
+    assert response.value.ok
+    heading = page.get_by_role(
+        "heading",
+        name="Brownfield site",
+    )
+    assert heading.is_visible()
+
+
 def test_give_feedback_on_a_dataset(
     server_process, BASE_URL, page, add_base_entities_to_database_yield_reset
 ):


### PR DESCRIPTION
Ticket: https://trello.com/c/mfv9lYPz/1030-add-an-e2e-test-for-navigate-to-a-dataset-specification

### What's new
- Added an acceptance test that tests navigation to a dataset page
### Why was this change made?
- because this user journey was documented as part of a recent group session we did