### PR TITLE
Test/navigate to organisation page from entity page

### DIFF
--- a/changeLog.md
+++ b/changeLog.md
@@ -14,6 +14,12 @@
 # ChangeLog
 <br>
 
+## 12-10-2023
+### What's new
+- Added acceptance test for navigating to the organisations page from the entity page
+### Why was this change made?
+- because this user journey was documented as part of a recent group session we did
+
 ## 10-10-2023
 ### What's new
 - Added an acceptance test that tests navigation to a dataset page

--- a/tests/acceptance/test_organisation.py
+++ b/tests/acceptance/test_organisation.py
@@ -1,3 +1,6 @@
+import re
+
+
 def test_organisation_page_loads_ok(server_process, BASE_URL, page):
     response = page.goto(BASE_URL + "/organisation")
     assert response.ok
@@ -6,3 +9,19 @@ def test_organisation_page_loads_ok(server_process, BASE_URL, page):
         name="Organisations",
     )
     assert heading.is_visible()
+
+
+def test_navigate_to_organisation_from_entity(server_process, BASE_URL, page):
+    page.goto(BASE_URL)
+    page.click("text=Search")
+
+    page.locator("dd").filter(has_text=re.compile(r"^DAC$")).get_by_role("link").click()
+
+    with page.expect_navigation() as navigation_info:
+        page.get_by_role("link", name="organisation").click()
+
+    assert navigation_info.value.ok
+    assert BASE_URL + "/organisation" in navigation_info.value.url
+
+    header = page.get_by_role("heading", name="Organisations")
+    assert header.is_visible()

--- a/tests/acceptance/test_organisation.py
+++ b/tests/acceptance/test_organisation.py
@@ -12,6 +12,8 @@ def test_navigate_to_organisation_from_entity(server_process, BASE_URL, page):
     page.goto(BASE_URL)
     page.click("text=Search")
 
+    page.screenshot("playwright-report/test_navigate_to_organisation_from_entity_1.png")
+
     page.get_by_role("link", name="DAC").first.click()
 
     with page.expect_navigation() as navigation_info:

--- a/tests/acceptance/test_organisation.py
+++ b/tests/acceptance/test_organisation.py
@@ -14,8 +14,6 @@ def test_navigate_to_organisation_from_entity(
     page.goto(BASE_URL)
     page.click("text=Search")
 
-    page.screenshot(path="playwright-report/test_map_page_loads_ok/map.png")
-
     page.get_by_role("link", name="DAC").first.click()
 
     with page.expect_navigation() as navigation_info:

--- a/tests/acceptance/test_organisation.py
+++ b/tests/acceptance/test_organisation.py
@@ -8,7 +8,9 @@ def test_organisation_page_loads_ok(server_process, BASE_URL, page):
     assert heading.is_visible()
 
 
-def test_navigate_to_organisation_from_entity(server_process, BASE_URL, page):
+def test_navigate_to_organisation_from_entity(
+    server_process, add_base_entities_to_database_yield_reset, BASE_URL, page
+):
     page.goto(BASE_URL)
     page.click("text=Search")
 

--- a/tests/acceptance/test_organisation.py
+++ b/tests/acceptance/test_organisation.py
@@ -1,6 +1,3 @@
-import re
-
-
 def test_organisation_page_loads_ok(server_process, BASE_URL, page):
     response = page.goto(BASE_URL + "/organisation")
     assert response.ok
@@ -15,7 +12,7 @@ def test_navigate_to_organisation_from_entity(server_process, BASE_URL, page):
     page.goto(BASE_URL)
     page.click("text=Search")
 
-    page.locator("dd").filter(has_text=re.compile(r"^DAC$")).get_by_role("link").click()
+    page.get_by_role("link", name="DAC").first.click()
 
     with page.expect_navigation() as navigation_info:
         page.get_by_role("link", name="organisation").click()

--- a/tests/acceptance/test_organisation.py
+++ b/tests/acceptance/test_organisation.py
@@ -12,7 +12,7 @@ def test_navigate_to_organisation_from_entity(server_process, BASE_URL, page):
     page.goto(BASE_URL)
     page.click("text=Search")
 
-    page.screenshot("playwright-report/test_navigate_to_organisation_from_entity_1.png")
+    page.screenshot(path="playwright-report/test_map_page_loads_ok/map.png")
 
     page.get_by_role("link", name="DAC").first.click()
 


### PR DESCRIPTION
Ticket: https://trello.com/c/naIgCdK9/1033-add-an-2e2-test-for-navigating-to-the-organization-index-via-the-entity-page

### What's new
- Added acceptance test for navigating to the organisations page from the entity page
### Why was this change made?
- because this user journey was documented as part of a recent group session we did