### PR TITLE
apply spatial relation to curie geom queries

### DIFF
--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -257,12 +257,12 @@ def _apply_location_filters(session, query, params):
                     EntityOrm.geometry.is_not(None),
                     func.ST_IsValid(EntityOrm.geometry),
                     func.ST_IsValid(curie_query.c.geometry),
-                    func.ST_Intersects(EntityOrm.geometry, curie_query.c.geometry),
+                    spatial_function(EntityOrm.geometry, curie_query.c.geometry),
                 ),
                 and_(
                     EntityOrm.point.is_not(None),
                     func.ST_IsValid(curie_query.c.geometry),
-                    func.ST_Intersects(EntityOrm.point, curie_query.c.geometry),
+                    spatial_function(EntityOrm.point, curie_query.c.geometry),
                 ),
             ),
         )

--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -201,7 +201,7 @@ def _apply_location_filters(session, query, params):
                     EntityOrm.geometry.is_not(None),
                     func.ST_IsValid(EntityOrm.geometry),
                     func.ST_IsValid(intersecting_entities_query.c.geometry),
-                    func.ST_Intersects(
+                    spatial_function(
                         EntityOrm.geometry,
                         intersecting_entities_query.c.geometry,
                     ),
@@ -209,7 +209,7 @@ def _apply_location_filters(session, query, params):
                 and_(
                     EntityOrm.point.is_not(None),
                     func.ST_IsValid(intersecting_entities_query.c.geometry),
-                    func.ST_Intersects(
+                    spatial_function(
                         EntityOrm.point, intersecting_entities_query.c.geometry
                     ),
                 ),
@@ -231,12 +231,12 @@ def _apply_location_filters(session, query, params):
                     EntityOrm.geometry.is_not(None),
                     func.ST_IsValid(EntityOrm.geometry),
                     func.ST_IsValid(reference_query.c.geometry),
-                    func.ST_Intersects(EntityOrm.geometry, reference_query.c.geometry),
+                    spatial_function(EntityOrm.geometry, reference_query.c.geometry),
                 ),
                 and_(
                     EntityOrm.point.is_not(None),
                     func.ST_IsValid(reference_query.c.geometry),
-                    func.ST_Intersects(EntityOrm.point, reference_query.c.geometry),
+                    spatial_function(EntityOrm.point, reference_query.c.geometry),
                 ),
             ),
         )

--- a/application/search/filters.py
+++ b/application/search/filters.py
@@ -170,26 +170,30 @@ class QueryFilters:
     geometry: Optional[List[str]] = Query(
         None,
         description="""
-        Search for entities with geometries intersecting with one or more geometries provided in WKT format""",
+        Search for entities with geometries interacting with one or more geometries provided in WKT format.
+        The type of geometric relation can be set using the geometry relation parameter.""",
     )
     geometry_entity: Optional[List[int]] = Query(
         None,
-        description="""Search for entities with geometries intersecting with one or more geometries
-        taken from each of the provided entities""",
+        description="""Search for entities with geometries interacting with one or more geometries
+        taken from each of the provided entities. The type of geometric relation can be set using the
+        geometry relation parameter.""",
         ge=1,
     )
     geometry_reference: Optional[List[str]] = Query(
         None,
         description="""
-        Search entities with geometries intersecting with the geometries of
-        entities with the provided references
+        Search entities with geometries interacting with the geometries of
+        entities with the provided references. The type of geometric relation
+        can be set using the geometry relation parameter.
         """,
     )
     geometry_curie: Optional[List[str]] = Query(
         None,
         description="""
-        Search for entities with geometries intersecting with geometries
-        entities matching provided curies
+        Search for entities with geometries interacting with geometries
+        entities matching provided curies. The type of geometric relation
+        can be set using the geometry relation parameter.
         """,
     )
     geometry_relation: Optional[GeometryRelation] = Query(


### PR DESCRIPTION
We currently quote in our documentation that the default spatial_relation used is within. This is incorrect and we have different defaults based on the parameters that someone uses