### PR TITLE
Turn LAD, LPA and parish references into links

### DIFF
--- a/application/templates/components/entity-value/macro.jinja
+++ b/application/templates/components/entity-value/macro.jinja
@@ -46,8 +46,10 @@
             <a class="govuk-link" href="{{ '/' + field + '/' + value }}">{{ value|replace("-", " ")|capitalize }}</a>
         {%- elif field in ["geometry","point"] %}
             <code class="app-code-block" tabindex="0">{{ value }}</code>
-        {%- elif field in ["local-resilience-forum","local-authority-type","ownership-status","planning-permission-type","planning-permission-type","planning-permission-status","green-belt-core","ancient-woodland-status","design-code-category","design-code-status","listed-building-grade","park-and-garden-grade","local-authority-district","local-planning-authority"] %}
+        {%- elif field in ["local-resilience-forum","local-authority-type","ownership-status","planning-permission-type","planning-permission-type","planning-permission-status","green-belt-core","ancient-woodland-status","design-code-category","design-code-status","listed-building-grade","park-and-garden-grade"] %}
             <a class ="govuk-link" href="{{ '/prefix/' + field + "/reference/" + value }}">{{ value }}</a>
+        {%- elif field in ["local-authority-district","local-planning-authority","parish"] %}
+            <a class ="govuk-link" href="{{ '/prefix/statistical-geography/reference/" + value }}">{{ value }}</a>
         {%- elif field in ["combined-authority","local-authority"] %}
             <a class ="govuk-link" href="{{ '/prefix/local-authority/reference/' + value }}">{{ value }}</a>
         {%- elif field in ["organisation-entity"] %}

--- a/application/templates/components/entity-value/macro.jinja
+++ b/application/templates/components/entity-value/macro.jinja
@@ -49,7 +49,7 @@
         {%- elif field in ["local-resilience-forum","local-authority-type","ownership-status","planning-permission-type","planning-permission-type","planning-permission-status","green-belt-core","ancient-woodland-status","design-code-category","design-code-status","listed-building-grade","park-and-garden-grade"] %}
             <a class ="govuk-link" href="{{ '/prefix/' + field + "/reference/" + value }}">{{ value }}</a>
         {%- elif field in ["local-authority-district","local-planning-authority","parish"] %}
-            <a class ="govuk-link" href="{{ '/prefix/statistical-geography/reference/" + value }}">{{ value }}</a>
+            <a class ="govuk-link" href="{{ '/prefix/statistical-geography/reference/' + value }}">{{ value }}</a>
         {%- elif field in ["combined-authority","local-authority"] %}
             <a class ="govuk-link" href="{{ '/prefix/local-authority/reference/' + value }}">{{ value }}</a>
         {%- elif field in ["organisation-entity"] %}

--- a/application/templates/components/entity-value/macro.jinja
+++ b/application/templates/components/entity-value/macro.jinja
@@ -46,7 +46,7 @@
             <a class="govuk-link" href="{{ '/' + field + '/' + value }}">{{ value|replace("-", " ")|capitalize }}</a>
         {%- elif field in ["geometry","point"] %}
             <code class="app-code-block" tabindex="0">{{ value }}</code>
-        {%- elif field in ["local-resilience-forum","local-authority-type","ownership-status","planning-permission-type","planning-permission-type","planning-permission-status","green-belt-core","ancient-woodland-status","design-code-category","design-code-status","listed-building-grade","park-and-garden-grade"] %}
+        {%- elif field in ["local-resilience-forum","local-authority-type","ownership-status","planning-permission-type","planning-permission-type","planning-permission-status","green-belt-core","ancient-woodland-status","design-code-category","design-code-status","listed-building-grade","park-and-garden-grade","local-authority-district","local-planning-authority"] %}
             <a class ="govuk-link" href="{{ '/prefix/' + field + "/reference/" + value }}">{{ value }}</a>
         {%- elif field in ["combined-authority","local-authority"] %}
             <a class ="govuk-link" href="{{ '/prefix/local-authority/reference/' + value }}">{{ value }}</a>


### PR DESCRIPTION
Turn local-authority-district and local-planning-authority and parish references into links, 

eg https://www.planning.data.gov.uk/entity/46 should link to https://www.planning.data.gov.uk/prefix/local-authority-district/reference/E07000129 

but we don't have a lookup so have made it https://www.planning.data.gov.uk/prefix/statistical-geography/reference/E07000129 

There's a lot of hard-coding here we should be able replace with inference and configuration in the specification.