### PR TITLE
removed boarder from phase banner on home page

### DIFF
--- a/application/templates/homepage.html
+++ b/application/templates/homepage.html
@@ -2,6 +2,7 @@
 {% extends "layouts/layout.html" %}
 {% block pageTitle %}Planning Data{% endblock %}
 {% set templateName = "dl-info/homepage.html" %}
+{% set hideBannerBorder = true %}
 
 {% block main %}
   <main id="content">

--- a/application/templates/partials/phase-banner.html
+++ b/application/templates/partials/phase-banner.html
@@ -1,11 +1,12 @@
 {% from "components/phase-banner/macro.jinja" import dlPhaseBanner %}
+
 {{
   dlPhaseBanner({
     'phase': 'Beta',
-    'html': 'This is a new service – to help us improve it, <a href="https://docs.google.com/forms/d/e/1FAIpQLSc1yzvw1Duv6nQRS56p379IxxMdAC5EfklMfUnCVMikgbi0Xw/viewform" target="_blank">sign up to take part in research</a>',
+    'html': 'This is a new service – to help us improve it, <a href="https://docs.google.com/forms/d/e/1FAIpQLSc1yzvw1Duv6nQRS56p379IxxMdAC5EfklMfUnCVMikgbi0Xw/viewform" target="_blank" class="govuk-link">sign up to take part in research</a>',
     'classes': 'govuk-width-container govuk-width-container' if not fullWidthHeader else 'govuk-width-container',
     'attributes': {
-      'style': '' if not fullWidthHeader else 'padding: 10px 30px; max-width: unset;'
+      'style': 'border-bottom: 0px' if hideBannerBorder else '' + '' if not fullWidthHeader else 'padding: 10px 30px; max-width: unset;'
     }
   })
 }}


### PR DESCRIPTION
Can't share ticket as trello is down

this PR was requested by Adam. it removes the boarder from the phase banner on the home page and also ensures that the link in the phase banner has the correct govuk-link classname