### PR TITLE
ensure json values are snake case

### DIFF
--- a/application/core/models.py
+++ b/application/core/models.py
@@ -5,6 +5,7 @@ from geoalchemy2.shape import to_shape
 from pydantic import BaseModel, Field, validator, Extra
 
 from application.db.models import EntityOrm
+from application.core.utils import to_snake
 
 
 def to_kebab(string: str) -> str:
@@ -128,7 +129,7 @@ def entity_factory(entity_orm: EntityOrm):
     e = EntityModel.from_orm(entity_orm)
     if entity_orm.json is not None:
         for key, val in entity_orm.json.items():
-            setattr(e, key, val)
+            setattr(e, to_snake(key), val)
     return e
 
 


### PR DESCRIPTION
when using the search endpoint there is an optional query parameter to change the fields that are returned. Unfortunately this doesn't work when you attempt to use values that contain '-' in that are stored in the json field of the database.

You can see this behaviour by examining this endpoint:
https://www.planning.data.gov.uk/entity.json?dataset=local-authority&field=local-planning-authority

I believe this is just because of how the entity factory stores the additional data values that are contained in the json

trello ticket:
https://trello.com/c/w4ayFG07/956-enable-field-select-for-json-fields