### PR TITLE
Revert "Entity row values to links"

### DIFF
--- a/application/core/filters.py
+++ b/application/core/filters.py
@@ -1,4 +1,4 @@
-from application.data_access.entity_queries import get_entity_query, get_entity_search
+from application.data_access.entity_queries import get_entity_query
 from application.core.utils import NoneToEmptyStringEncoder
 from jinja2 import pass_eval_context
 from markdown import markdown
@@ -172,30 +172,6 @@ def get_entity_name_filter(eval_ctx, entity):
                 return entity.name
             else:
                 return entity.reference
-
-
-@pass_eval_context
-def lookup_entity_filter(eval_ctx, value, dataset):
-    "lookup an entity by its name or reference"
-    search_parameters = {
-        "reference": [value],
-        "dataset": [dataset],
-    }
-    params, count, entities = get_entity_search(search_parameters).values()
-
-    if len(entities) == 1:
-        return entities[0].entity
-
-
-@pass_eval_context
-def lookup_entity_custom_filter(eval_ctx, value, dataset):
-
-    datasetMapping = {"permitted-development-rights": "permitted-development-right"}
-
-    if dataset in datasetMapping:
-        dataset = datasetMapping[dataset]
-
-    return lookup_entity_filter(eval_ctx, value, dataset)
 
 
 def get_entity_name(entity):

--- a/application/core/models.py
+++ b/application/core/models.py
@@ -136,8 +136,7 @@ class DatasetPublicationCountModel(DigitalLandBaseModel):
 
 def entity_factory(entity_orm: EntityOrm):
     e = EntityModel.from_orm(entity_orm)
-
-    if hasattr(entity_orm, "json") and entity_orm.json is not None:
+    if entity_orm.json is not None:
         # if values in json present then extend the pydantic model
         # TODO could add in additional validation using field informtion
         field_definitions = {

--- a/application/core/templates.py
+++ b/application/core/templates.py
@@ -11,8 +11,6 @@ from application.core.filters import (
     render_markdown,
     entity_name_filter,
     get_entity_name_filter,
-    lookup_entity_filter,
-    lookup_entity_custom_filter,
     debug,
     digital_land_to_json,
     uri_encode,
@@ -75,8 +73,6 @@ templates.env.filters["make_param_str"] = make_param_str_filter
 templates.env.filters["render_markdown"] = render_markdown
 templates.env.filters["entity_name"] = entity_name_filter
 templates.env.filters["get_entity_name"] = get_entity_name_filter
-templates.env.filters["lookup_entity"] = lookup_entity_filter
-templates.env.filters["lookup_entity_custom"] = lookup_entity_custom_filter
 templates.env.filters["debug"] = debug
 templates.env.filters["digital_land_to_json"] = digital_land_to_json
 templates.env.filters["uri_encode"] = uri_encode

--- a/application/templates/components/entity-value/macro.jinja
+++ b/application/templates/components/entity-value/macro.jinja
@@ -66,8 +66,6 @@
                     {{ value }}
                 {% endif %}
             </a>
-        {%- elif field in ["article-4-direction", "permitted-development-rights", "tree-preservation-order"] %}
-            <a class ="govuk-link" href="/entity/{{ value | lookup_entity_custom(field) }}">{{ value }}</a>
         {%- elif field in ["parliament-thesaurus"] %}
             <a class ="govuk-link" href="{{ 'https://lda.data.parliament.uk/terms/' + value }}">{{ value }}</a>
         {%- elif field in ["statistical-geography"] %}


### PR DESCRIPTION
this PR was causing some issues, and needs redoing anyway as as part of this ticket : https://trello.com/c/IScKOoaR/1206-remove-database-interactions-that-happen-in-the-filters-in-the-view-and-add-it-to-the-controller
so for now we will revert this and pick up the new ticket later this week

Broken on prod: https://www.planning.data.gov.uk/entity/7002000975
Fixed on dev: https://www.development.digital-land.info/entity/7002000975