### PR TITLE
Adding json response for 410 when triggered with extension .json

### DIFF
--- a/application/routers/entity.py
+++ b/application/routers/entity.py
@@ -81,7 +81,8 @@ def get_entity(
     if old_entity_status == 410:
         if extension:
             raise HTTPException(
-                detail=f"Entity {entity} has been removed", status_code=410
+                detail=f"Entity {entity} has been removed",
+                status_code=410,
             )
         else:
             return templates.TemplateResponse(
@@ -284,7 +285,7 @@ def search_entities(
     columns = ["dataset", "name", "plural", "typology", "themes", "paint_options"]
     datasets = [dataset.dict(include=set(columns)) for dataset in response]
 
-    local_authorities = get_local_authorities(session, "local-authority-eng")
+    local_authorities = get_local_authorities(session, "local-authority")
     local_authorities = [la.dict() for la in local_authorities]
 
     if links.get("prev") is not None:

--- a/application/routers/entity.py
+++ b/application/routers/entity.py
@@ -79,13 +79,19 @@ def get_entity(
     e, old_entity_status, new_entity_id = get_entity_query(session, entity)
 
     if old_entity_status == 410:
-        return templates.TemplateResponse(
-            "entity-gone.html",
-            {
-                "request": request,
-                "entity": str(entity),
-            },
-        )
+        if extension:
+            raise HTTPException(
+                detail=f"Entity {entity} has been removed", status_code=410
+            )
+        else:
+            return templates.TemplateResponse(
+                "entity-gone.html",
+                {
+                    "request": request,
+                    "entity": str(entity),
+                },
+                status_code=410,
+            )
     elif old_entity_status == 301:
         if extension:
             return RedirectResponse(
@@ -278,7 +284,7 @@ def search_entities(
     columns = ["dataset", "name", "plural", "typology", "themes", "paint_options"]
     datasets = [dataset.dict(include=set(columns)) for dataset in response]
 
-    local_authorities = get_local_authorities(session, "local-authority")
+    local_authorities = get_local_authorities(session, "local-authority-eng")
     local_authorities = [la.dict() for la in local_authorities]
 
     if links.get("prev") is not None:

--- a/application/templates/entity-gone.html
+++ b/application/templates/entity-gone.html
@@ -12,7 +12,6 @@
     This entity (#{{entity}}) has been removed.
   </p>
 
-  {%- from "components/feedback/macro.jinja" import dlFeedback %}
   {% set subject = "Feedback on removed entity with number " + entity %}
   <div class="govuk-body">
     Spotted an issue? You can

--- a/application/templates/entity-gone.html
+++ b/application/templates/entity-gone.html
@@ -1,35 +1,24 @@
 {% extends "layouts/layout.html" %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
 {% set templateName = "dl-info/entity-gone.html" %}
 
 {%- block content %}
 
-  {% block recordHead %}
-    {% block recordTitle -%}
-      <span class="govuk-caption-xl">Entity Removed</span>
-      <h1 class="govuk-heading-xl">Entity Removed</h1>
-    {%- endblock recordTitle %}
-  {% endblock recordHead %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Entity Removed</h1>
 
   <p class="govuk-body">
     This entity (#{{entity}}) has been removed.
   </p>
 
-  {%- endblock content %}
-
-  {% block recordEnd %}{% endblock recordEnd %}
-
-  {% block footerStart %}
-    {%- from "components/feedback/macro.jinja" import dlFeedback %}
-    {% set subject = "Feedback on removed entity with number " + entity %}
-    {{ dlFeedback({
-        "text": "Spotted an issue? Let us know so we can improve the data.",
-        "action": {
-            "text": "There is something wrong with the data",
-            "href": "mailto:" + templateVar.email  + "?subject=" + subject
-        },
-        "container": true
-        })
-      }}
-  {% endblock footerStart %}
-
-  {%- block pageScripts %}{%- endblock %}
+  {%- from "components/feedback/macro.jinja" import dlFeedback %}
+  {% set subject = "Feedback on removed entity with number " + entity %}
+  <div class="govuk-body">
+    Spotted an issue? You can
+    <a href="mailto:{{ templateVar.email }}?subject={{ subject }}" class="govuk-link"> contact the Planning Data team </a>
+    if you need to speak to someone about this page.
+  </div>
+</div>
+</div>
+{%- endblock %}

--- a/application/templates/entity-gone.html
+++ b/application/templates/entity-gone.html
@@ -8,16 +8,16 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Entity Removed</h1>
 
-  <p class="govuk-body">
-    This entity (#{{entity}}) has been removed.
-  </p>
+    <p class="govuk-body">
+      This entity (#{{ entity }}) has been removed.
+    </p>
 
-  {% set subject = "Feedback on removed entity with number " + entity %}
-  <div class="govuk-body">
-    Spotted an issue? You can
-    <a href="mailto:{{ templateVar.email }}?subject={{ subject }}" class="govuk-link"> contact the Planning Data team </a>
-    if you need to speak to someone about this page.
+    {% set subject = "Feedback on removed entity with number " + entity %}
+    <div class="govuk-body">
+      Spotted an issue? You can
+      <a href="mailto:{{ templateVar.email }}?subject={{ subject }}" class="govuk-link"> contact the Planning Data team </a>
+      if you need to speak to someone about this page.
+    </div>
   </div>
-</div>
 </div>
 {%- endblock %}

--- a/application/templates/entity-gone.html
+++ b/application/templates/entity-gone.html
@@ -3,21 +3,20 @@
 {% set templateName = "dl-info/entity-gone.html" %}
 
 {%- block content %}
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Entity Removed</h1>
-
-    <p class="govuk-body">
-      This entity (#{{ entity }}) has been removed.
-    </p>
-
-    {% set subject = "Feedback on removed entity with number " + entity %}
-    <div class="govuk-body">
-      Spotted an issue? You can
-      <a href="mailto:{{ templateVar.email }}?subject={{ subject }}" class="govuk-link"> contact the Planning Data team </a>
-      if you need to speak to someone about this page.
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Entity Removed</h1>
+  
+      <p class="govuk-body">
+        This entity (#{{ entity }}) has been removed.
+      </p>
+  
+      {% set subject = "Feedback on removed entity with number " + entity %}
+      <div class="govuk-body">
+        Spotted an issue? You can
+        <a href="mailto:{{ templateVar.email }}?subject={{ subject }}" class="govuk-link"> contact the Planning Data team </a>
+        if you need to speak to someone about this page.
+      </div>
     </div>
   </div>
-</div>
 {%- endblock %}

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -124,6 +124,24 @@ def test_old_entity_gone_shown(test_data_old_entities, client, exclude_middlewar
     assert (
         f"This entity (#{old_entity.old_entity_id}) has been removed." in response.text
     )
+    assert (
+        "text/html" in response.headers["Content-Type"]
+    ), "Expected response in text/html format"
+
+
+def test_old_entity_gone_json_shown(test_data_old_entities, client, exclude_middleware):
+    """
+    Test entity endpoint returns entity gone content
+    """
+    old_entity = test_data_old_entities["old_entities"][410][0]
+    response = client.get(
+        f"/entity/{old_entity.old_entity_id}.json", allow_redirects=False
+    )
+    assert response.status_code == 410
+    assert (
+        response.headers["Content-Type"] == "application/json"
+    ), "Expected response in JSON format"
+    assert f"Entity {old_entity.old_entity_id} has been removed" in response.text
 
 
 def test_dataset_json_endpoint_returns_as_expected(test_data, client):
@@ -308,6 +326,9 @@ def test_get_by_curie_redirects_to_entity(test_data, client, exclude_middleware)
 def test_get_by_curie_404s_for_unknown_reference(test_data, client, exclude_middleware):
     response = client.get("/curie/not:found", allow_redirects=False)
     assert response.status_code == 404
+    expected_content = "Page not found"
+    # Check if the expected content is present in the response body
+    assert expected_content in response.text
 
 
 def test_get_dataset_unknown_returns_404(client, exclude_middleware):

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -120,7 +120,7 @@ def test_old_entity_gone_shown(test_data_old_entities, client, exclude_middlewar
     """
     old_entity = test_data_old_entities["old_entities"][410][0]
     response = client.get(f"/entity/{old_entity.old_entity_id}", allow_redirects=False)
-    assert response.status_code == 200
+    assert response.status_code == 410
     assert (
         f"This entity (#{old_entity.old_entity_id}) has been removed." in response.text
     )

--- a/tests/unit/routers/test_entity.py
+++ b/tests/unit/routers/test_entity.py
@@ -212,16 +212,11 @@ def test_get_entity_old_entity_gone_returned_json(mocker):
     request = MagicMock()
     extension = MagicMock()
     extension.value = "json"
-    result = get_entity(request=request, entity="11000000", extension=extension)
     try:
-        result.template.render(result.context)
+        get_entity(request=request, entity="11000000", extension=extension)
+        assert False, "Expected HTTPException to be raised"
+    except HTTPException:
         assert True
-    except Exception:
-        if hasattr(result, "context"):
-            logging.warning(f"context:{result.context}")
-        else:
-            logging.warning("result has no context")
-        assert False, "template unable to render, missing variable(s) from context"
 
 
 def test_get_entity_old_entity_gone_returned_geojson(mocker):
@@ -231,16 +226,11 @@ def test_get_entity_old_entity_gone_returned_geojson(mocker):
     request = MagicMock()
     extension = MagicMock()
     extension.value = "geojson"
-    result = get_entity(request=request, entity="11000000", extension=extension)
     try:
-        result.template.render(result.context)
+        get_entity(request=request, entity="11000000", extension=extension)
+        assert False, "Expected HTTPException to be raised"
+    except HTTPException:
         assert True
-    except Exception:
-        if hasattr(result, "context"):
-            logging.warning(f"context:{result.context}")
-        else:
-            logging.warning("result has no context")
-        assert False, "template unable to render, missing variable(s) from context"
 
 
 def test_get_entity_old_entity_redirect_returned_html(mocker):


### PR DESCRIPTION
Reference ticket: https://trello.com/c/MNP2L46O/1405-bug-410-responses

- Returns status code 410 instead of 200 for 'Entity removed' page
- Added case for returning json response for 410s when called with .json extension
- Changed the html page content/design for 410 to match other error pages
- Updated test cases to reflect the changes