### PR TITLE
add document-url to conservation area dataset guidance

### DIFF
--- a/application/templates/pages/guidance/specifications/conservation-area.md
+++ b/application/templates/pages/guidance/specifications/conservation-area.md
@@ -57,11 +57,17 @@ Example: `MULTIPOLYGON (((1.188829 51.23478,1.188376 51.234909,1.188381 51.23491
 
 If you’re providing geometry in a GeoJSON, GML or Geopackage, use the associated geometry format.
 
+### document-url
+
+A URL to the document containing the authoritative source for the area. This is usually a PDF containing the area drawn on a map.
+
+Example: `http://www.LPAwebsite.org.uk/data/conservationareas/smithroad-area.pdf`
+
 ### documentation-url
 
 The URL of the webpage on your website that introduces the document.
 
-Each document should be linked to from a documentation webpage that includes a short description of the data and the document you’re linking to. Each conservation area should have a unique URL. This means you can create a separate page for each one, or you could list several on one page. If you do that, there must be a separate anchor (fragment identifier) for each one. 
+Each document should be linked to from a documentation webpage that includes a short description of the data and the document you’re linking to. Each conservation area should have a unique URL. This means you can create a separate page for each one, or you could list several on one page. If you do that, there must be a separate anchor (fragment identifier) for each one.
 
 This means each section of your page should have its own URL. Most publishing systems will allow you to use a hashtag to create the identifiers for each conservation area you list - as in the examples shown.
 


### PR DESCRIPTION
This is to bring the guidance in line with the recent change to the spec (see [4ab4af289](https://github.com/digital-land/specification/pull/71/commits/4ab4af289c85bd375a46e45c4d1c471d78f48027))