### PR TITLE
More item links

### DIFF
--- a/application/templates/components/entity-value/macro.jinja
+++ b/application/templates/components/entity-value/macro.jinja
@@ -82,7 +82,7 @@
             {%- endif %}
         {%- elif field == "twitter" %}
             <a class ="govuk-link" href="https://twitter.com/{{ value }}">@{{ value }}</a>
-        {%- elif field in ["website","opendatacommunities","documentation-url","document-url","site-plan-url"] %}
+        {%- elif field in ["website","opendatacommunities"] or field.endswith("-url") or field.endswith("-uri")] %}
             <a class ="govuk-link" href="{{ value }}">{{ value }}</a>
         {%- elif field in ["wikipedia"] %}
             <a class ="govuk-link" href="{{ 'https://en.wikipedia.org/wiki/' + value }}">{{ value }}</a>

--- a/application/templates/components/entity-value/macro.jinja
+++ b/application/templates/components/entity-value/macro.jinja
@@ -54,7 +54,7 @@
             <code class="app-code-block" tabindex="0">{{ value }}</code>
         {%- elif field in ["local-resilience-forum","local-authority-type","ownership-status","planning-permission-type","planning-permission-type","planning-permission-status","green-belt-core","ancient-woodland-status","design-code-category","design-code-status","listed-building-grade","park-and-garden-grade"] %}
             <a class ="govuk-link" href="{{ '/prefix/' + field + "/reference/" + value }}">{{ value }}</a>
-        {%- elif field in ["local-authority-district","local-planning-authority","parish"] %}
+        {%- elif field in ["local-authority-district","local-planning-authority","parish","region"] %}
             <a class ="govuk-link" href="{{ '/prefix/statistical-geography/reference/' + value }}">{{ value }}</a>
         {%- elif field in ["combined-authority","local-authority"] %}
             <a class ="govuk-link" href="{{ '/prefix/local-authority/reference/' + value }}">{{ value }}</a>


### PR DESCRIPTION
Turn the region value into a link to the `region` entity page, and the opendatacommunities-uri to a link to https://opendatacommunities.org

Should fix organisation pages such as https://www.planning.data.gov.uk/entity/63 where these values are currently just text:

![image](https://github.com/digital-land/digital-land.info/assets/5833/8bdd122c-dbc2-4418-be90-458428e2216b)
