### PR TITLE
Add Q2 2024 roadmap

### DIFF
--- a/application/templates/pages/about/roadmap.md
+++ b/application/templates/pages/about/roadmap.md
@@ -1,16 +1,16 @@
 This roadmap shows our current plans for making it easier to find planning and housing data that is easy to find, use and trust.
 
-We work in 3-month cycles and we will update this roadmap every month. Our plans can change based on what we learn from speaking to our users, testing iterations, and how we can better deliver on our mission.
+We work in 3-month cycles and we aim to update this roadmap every month. Our plans can change based on what we learn from speaking to our users, testing iterations, and how we can better deliver on our mission.
 
-Last updated 12 April 2024.
+Last updated 17 July 2024.
 
 ## Local planning authorities (LPAs)
 
-We’re working with 71 LPAs through the [Open Digital Planning community](https://opendigitalplanning.org/community) to help them provide data through our platform, so they can use the [PlanX](https://opendigitalplanning.org/services) and [BoPS](https://bops.digital) digital planning products.
+We’re working with 71 LPAs through the [Open Digital Planning community](https://opendigitalplanning.org/community-members) to help them provide data through our platform, so they can use the [PlanX](https://opendigitalplanning.org/services) and [BoPS](https://bops.digital) digital planning products.
 
 ### Now
 
-- We’re working to onboard 43 more LPAs.
+- We’ve onboarded 43 more LPAs and run regular drop-in sessions and working groups to address challenges, blockers and opportunities
 
 ### Next
 
@@ -18,46 +18,49 @@ We’re working with 71 LPAs through the [Open Digital Planning community](https
 
 ## Data
 
-We are developing data standards and collecting data that is valuable to housing and planning, and improving the quantity and quality of data on the platform.
+We are designing and collecting data that is valuable to housing and planning, and improving the quantity and quality of data on the platform.
+
+We regularly ask our community to help us decide the things we need to work on and tell us what they need from the data. Read our [code of conduct](https://github.com/digital-land/data-standards-backlog/discussions/47) to see how you can contribute.
 
 ### Now
 
-We are working with LPA partners for these areas:
+We are working with LPA partners to provide data for these areas:
 
 -   [conservation areas](/dataset/conservation-area)
 -   [listed buildings](/dataset/listed-building) and their [outlines](/dataset/listed-building-outline)
 -   [Article 4 directions](/dataset/article-4-direction) and their [areas](/dataset/article-4-direction-area)
 -   [tree preservation orders](/dataset/tree-preservation-order)
 
-We are improving the visibility, participation and robustness of the standards design process.
+We are improving the visibility, participation and robustness of the [data design process](https://design.planning.data.gov.uk/data-design-process). You can take a look at [data standards we’re working on now](https://design.planning.data.gov.uk/what-we-are-working-on#:~:text=you%20can%20contribute.-,Working%20on%20now,-These%20are%20the).
 
 ### Next
 
-We will continue to develop standards in the following areas:
+You can take a look at [data standards emerging as priorities](https://design.planning.data.gov.uk/what-we-are-working-on#:~:text=Planning%20applications%20%26%20decisions-,Emerging%20priorities,-These%20are%20the), based on department objectives and our analysis of what will add the most value.
 
--   [design codes](/dataset/design-code)
--   local plans ([draft specification](https://digital-land.github.io/specification/specification/development-plan/))
--   planning applications ([draft specification](https://digital-land.github.io/specification/specification/planning-application/)) and decisions
+We will research how easy the platform is for data consumers and planning policymakers to use, so that we can understand how the platform is being used currently and how well it meets their needs.
 
 ## Platform
 
 ### Now
 
-- We are scaling our data processing to support more LPAs checking their data at once, and to make the platform more resilient when processing large datasets
-- We are improving our processes to identify data quality issues faster and give better feedback more quickly to LPAs on their data
-- We are implementing performance measures, analytics and other metrics to raise the visibility of the performance of the service
+We are scaling our data processing to support many more organisations and much larger datasets, remaining performant throughout. This includes increasing the number of [title boundaries](https://www.planning.data.gov.uk/dataset/title-boundary) from covering 25 to 311 local planning authorities. We will determine and implement alerts for the most important functions of the data pipeline.
+
+We are improving the quality of datasets on the platform, reducing the number of data issues across all datasets and monitoring the number of stale endpoints across the platform. We will reduce operational bottlenecks when managing data, in readiness for local planning authorities providing more datasets sooner. We will enable the assessment of land use by testing an approach for seeding the largest known collection of national planning datasets.
+
+We will help local planning authorities understand issues with the datasets they’ve provided, and guide and support them through the process of fixing these, to increase the quality of the data provided and the number of datasets conforming to the standards. We will do this through [our service for data providers](/guidance/).
 
 ### Next
 
-- We will give LPAs feedback on issues with their datasets and a way to track progress on tasks, to make it easier to improve and provide all data iteratively
-- We will test an approach for seeding and adopting local data (for local plans, conservation areas, Article 4 directions, and design codes) to start with what exists and reduce effort for LPAs when preparing data
-- We will show data an organisation must provide (statutory), has been funded to provide (expected) or where there is a standard under development (prospective) 
+- We will create a statutory instrument for our policy areas and considerations
+- We will explain the principles that guide us in making planning and housing data easy to find at a national scale
+- We will explain our quality-checking processes and the development stages for certain datasets, making what we do transparent so that the data is easier to trust
+- We will work with data consumers to iterate our API, supporting a growing market of planning products and services using open data we make available
 
 ### Later
 
-- We will explore alternative options for warehousing reporting data to make it cheaper to run the platform 
-- We will investigate how we might filter geographical features outside of the organisation boundary 
-- We will make users more aware of how their data is benefitting other people and organisations 
+- We will explore alternative options for warehousing reporting data to make it cheaper to run the platform
+- We will investigate how we might filter geographical features outside of the organisation boundary
+- We will make users more aware of how their data is benefitting other people and organisations
 - We will explore better ways of searching and finding documents on the site
 
 <br>


### PR DESCRIPTION
This was on my task list for the week, but coincidentally the folks at [Public Digital posted a blog post about public backlogs and open roadmaps today](https://public.digital/pd-insights/blog/2024/07/filling-in-the-gaps-the-case-for-public-backlogs-roadmaps). It felt like the right time to update our roadmap following setting Q2 OKRs.

I've also included links to our [data design backlog](https://design.planning.data.gov.uk/what-we-are-working-on). Once we've populated the roadmap for the [service for data providers](https://check.planning.data.gov.uk/), I'll add that too (it'll be [on GitHub](https://github.com/orgs/digital-land/projects)).