### PR TITLE
change href to entity

### DIFF
--- a/application/templates/organisation_index.html
+++ b/application/templates/organisation_index.html
@@ -59,7 +59,7 @@
       <ol class="dl-list-filter__list" data-filter="list">
         {% for organisation in organisations[org_type]|sort(attribute='name')  %}
           <li class="dl-list-filter__item" data-filter="item">
-            <a href="/curie/{{ organisation.organisation }}" class="govuk-link dl-list-filter__item-title">{{ organisation.name }}</a>
+            <a href="/entity/{{ organisation.entity }}" class="govuk-link dl-list-filter__item-title">{{ organisation.name }}</a>
             {% if organisation.end_date and organisation.end_date < today  %}
               <strong class="govuk-tag govuk-tag--grey">
                 Dissolved


### PR DESCRIPTION
currently the organisation page uses curies to link to organisation entities. The problem with this is that the wrong prefixes are being used as some datasets have wikidata prefixes because the references are taken from wikidata. 

Currently the application doesn't have the logic or information to understand what prefixes should be used so instead we'll switch them to using links which reference the entity directly.