### PR TITLE
Add guidance on the field names we accept

### DIFF
--- a/application/templates/pages/guidance/specifications/article-4-direction.md
+++ b/application/templates/pages/guidance/specifications/article-4-direction.md
@@ -22,6 +22,19 @@ You can provide data in one of these formats:
 
 These may be uploaded to a single URL, or served via an OGC WFS or ArcGIS API.
 
+Field names
+-----------
+
+You can provide fields names using hyphens, underscores or spaces.
+
+For example:
+
+- `start-date`
+- `start_date`
+- `start date`
+
+These are all valid, and any uppercase characters will be converted to lowercase.
+
 ---
 
 ## Article 4 direction dataset
@@ -64,7 +77,7 @@ Example: `http://www.LPAwebsite.org.uk/article4direction1.pdf`
 
 The URL of the webpage on your website that introduces the document.
 
-Each document should be linked to from a documentation webpage that includes a short description of the data and the document you’re linking to. Each article 4 direction should have a unique URL. This means you can create a separate page for each one, or you could list several on one page. If you do that, there must be a separate anchor link (fragment identifier) for each one. 
+Each document should be linked to from a documentation webpage that includes a short description of the data and the document you’re linking to. Each article 4 direction should have a unique URL. This means you can create a separate page for each one, or you could list several on one page. If you do that, there must be a separate anchor link (fragment identifier) for each one.
 
 This means each section of your page should have its own URL. Most publishing systems will allow you to use a hashtag to create the identifiers for each article 4 direction you list - as in the examples shown.
 

--- a/application/templates/pages/guidance/specifications/conservation-area.md
+++ b/application/templates/pages/guidance/specifications/conservation-area.md
@@ -2,7 +2,7 @@ There are 2 datasets you must provide for conservation area data:
 
 * [conservation area dataset](https://www.planning.data.gov.uk/guidance/specifications/conservation-area#conservation-area-dataset)
 * [conservation area document dataset](https://www.planning.data.gov.uk/guidance/specifications/conservation-area#conservation-area-documents-dataset)
-  
+
 ## Format
 
 You can provide data in one of these formats:
@@ -11,8 +11,20 @@ You can provide data in one of these formats:
 * GeoJSON
 * GML
 * Geopackage
-  
+
 These may be uploaded to a single URL, or served via an OGC WFS or ArcGIS API.
+
+## Field names
+
+You can provide fields names using hyphens, underscores or spaces.
+
+For example:
+
+* `start-date`
+* `start_date`
+* `start date`
+
+These are all valid, and any uppercase characters will be converted to lowercase.
 
 ## Conservation area dataset
 
@@ -50,7 +62,7 @@ If you’re providing geometry in a GeoJSON, GML or Geopackage, use the associat
 
 The date that the conservation area was officially designated, written in YYYY-MM-DD format.
 
-Example:  
+Example:
 
 `1984-03-28`
 
@@ -78,7 +90,7 @@ Examples:
 One conservation area per page:
 `http://www.LPAwebsite.org.uk/data/conservationareas/smithroad`
 
-More than one conservation area per page with an anchor link for each one:  
+More than one conservation area per page with an anchor link for each one:
 
 `http://www.LPAwebsite.org.uk/data/conservationareas#smithroad`
 
@@ -99,11 +111,11 @@ If the entity has never been updated, enter the same date as start-date.
 
 Write in YYYY-MM-DD format.
 
-Example:  
+Example:
 
 `2022-12-20`
 
-With dates, some data is better than no data, so:  
+With dates, some data is better than no data, so:
 
 * `2022` is fine
 * `2022-12` is better
@@ -113,7 +125,7 @@ With dates, some data is better than no data, so:
 
 The date the validity of the record starts, written in YYYY-MM-DD format. Usually, this will be the same as the designation date. If anything about the conservation area has changed, for example, the boundary, it should be the date of that change.
 
-Example:  
+Example:
 
 `1984-04-25`
 
@@ -127,7 +139,7 @@ With dates, some data is better than no data, so:
 
 Where the conservation area is no longer valid, this should be the date that it was no longer in effect, written in YYYY-MM-DD format. If this does not apply, leave the cell blank.
 
-Example:  
+Example:
 
 `1999-01-20`
 
@@ -151,7 +163,7 @@ These documents are the authoritative source and provide the context around the 
 * notices of conservation area designations
 * management plans
 * gazette entries
-  
+
 Don’t worry if you don’t have all the data we’ve asked for available right now. If you give us what you’ve got, we can help you fill in the gaps later.
 
 A complete record should contain the following fields (columns):
@@ -162,7 +174,7 @@ A reference or ID for each document that is:
 
 * unique within your dataset
 * permanent - it doesn't change when the dataset is updated
-  
+
 If you don't use a reference already, you will need to create one. This can be a short set of letters or numbers.
 
 Example: `CADOC01`
@@ -212,7 +224,7 @@ If the entity has never been updated, enter the same date as start-date.
 
 Write in YYYY-MM-DD format.
 
-Example:  
+Example:
 
 `1984-03-28`
 
@@ -226,7 +238,7 @@ With dates, some data is better than no data, so:
 
 The date the document was published, written in YYYY-MM-DD format.
 
-Example:  
+Example:
 
 `1984-03-28`
 
@@ -240,7 +252,7 @@ With dates, some data is better than no data, so:
 
 The date the document was withdrawn or superseded by another document, written in YYYY-MM-DD format. Leave this blank if the document is still relevant to planning.
 
-Example:  
+Example:
 
 `1984-03-28`
 
@@ -249,5 +261,3 @@ With dates, some data is better than no data, so:
 * `1984` is fine
 * `1984-03` is better
 * `1984-03-28` is brilliant
-
-

--- a/application/templates/pages/guidance/specifications/listed-building.md
+++ b/application/templates/pages/guidance/specifications/listed-building.md
@@ -19,6 +19,18 @@ You can provide data in one of these formats:
 
 These may be uploaded to a single URL, or served via an OGC WFS or ArcGIS API.
 
+## Field names
+
+You can provide fields names using hyphens, underscores or spaces.
+
+For example:
+
+* `start-date`
+* `start_date`
+* `start date`
+
+These are all valid, and any uppercase characters will be converted to lowercase.
+
 Listed buildings outline dataset
 ------------------------
 

--- a/application/templates/pages/guidance/specifications/tree-preservation-order.md
+++ b/application/templates/pages/guidance/specifications/tree-preservation-order.md
@@ -24,6 +24,18 @@ You can provide the zone and individual tree data in one of these formats:
 
 These may be uploaded to a single URL, or served via an OGC WFS or ArcGIS API.
 
+## Field names
+
+You can provide fields names using hyphens, underscores or spaces.
+
+For example:
+
+* `start-date`
+* `start_date`
+* `start date`
+
+These are all valid, and any uppercase characters will be converted to lowercase.
+
 Tree preservation order dataset
 -------------------------------
 


### PR DESCRIPTION
A user at an LPA raised the following query.

> A few weeks ago, I was invited to participate in testing for the four planning datasets that the government plans to publish. I have identified an issue that I would like to bring to your attention. While we successfully uploaded a .CSV file as a user, it was communicated that this method is not the preferred approach. Instead, using a REST API seems to be the better option. However, upon reviewing the technical documentation, I noticed that many of the column headers contain hyphens (-), which are not supported in the ESRI ecosystem. Here’s a link below; it’s something I would have never considered using within a header name.
>
> https://digital-land.github.io/specification/specification/article-4-direction/
>
> What characters should not be used in ArcGIS for field names and table names
>
> https://support.esri.com/en-us/knowledge-base/what-characters-should-not-be-used-in-arcgis-for-field--000005588

After checking with @eveleighoj and @psd, we can accept field names using characters other than hyphens. We normalise the field names received from data providers but then transform it into kebab-case in the output.

## Preview

<img width="1581" alt="image" src="https://github.com/user-attachments/assets/4d426459-548d-42db-a675-f2eea7c81259">