### PR TITLE
Top links to API and Design data

### DIFF
--- a/application/templates/partials/mast-head.html
+++ b/application/templates/partials/mast-head.html
@@ -24,7 +24,11 @@
         },
         {
             "href": "/docs",
-            "text": "Documentation"
+            "text": "API"
+        },
+        {
+            "href": "https://design.planning.data.gov.uk",
+            "text": "Design data"
         },
         {
             "href": "/guidance",

--- a/tests/acceptance/test_acceptance.py
+++ b/tests/acceptance/test_acceptance.py
@@ -30,7 +30,7 @@ def test_acceptance(
     page.click("text=Datasets")
     assert page.url == f"{server_url}/dataset/"
 
-    page.click("text=Documentation")
+    page.click("text=API")
     assert page.url == f"{server_url}/docs"
     assert page.text_content("h1") == "Documentation"
     page.goto(server_url)

--- a/tests/acceptance/test_acceptance.py
+++ b/tests/acceptance/test_acceptance.py
@@ -61,7 +61,7 @@ def test_get_healthcheck(server_url):
 def test_documentation_page(server_url, page: Page):
     page.goto(server_url)
     expect(page).to_have_title(re.compile("Planning Data"))
-    documentation = page.get_by_role("link", name="Documentation", exact=True)
+    documentation = page.get_by_role("link", name="API", exact=True)
     expect(documentation).to_have_attribute("href", "/docs")
     documentation.click()
 

--- a/tests/acceptance/test_documentation.py
+++ b/tests/acceptance/test_documentation.py
@@ -13,7 +13,7 @@ def test_docs_page_loads_ok(server_url, page):
 
 def test_accessing_the_openAPI_file_and_the_swagger_editor(server_url, page):
     page.goto(server_url)
-    page.get_by_role("link", name="Documentation", exact=True).click()
+    page.get_by_role("link", name="API", exact=True).click()
 
     with page.expect_navigation() as navigation_info:
         page.get_by_role(


### PR DESCRIPTION
I keep being asked if we have an API, so changed the "Documentation" top link to be "API".

Also, added a headline link to "Design data" which was missing.