### PR TITLE
Fix: Use current version of app in security scanning

### DIFF
--- a/docker-compose.security.yml
+++ b/docker-compose.security.yml
@@ -7,7 +7,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    image: public.ecr.aws/l6z6v3j6/digital-land-platform:${DOCKER_APPLICATION_TAG-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
     environment:
       ENVIRONMENT: production
       S3_HOISTED_BUCKET: https://digital-land-production-collection-dataset-hoisted.s3.eu-west-2.amazonaws.com


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Change version of app to latest when performing security scanning

Docker compose configuration for security scanning was referencing a version of the frontend from around 2 years ago.

## Related Tickets & Documents

- Ticket Link: https://trello.com/c/7mOAVwFo/3443-address-high-priority-security-issue-on-digital-land-platform

## QA Instructions, Screenshots, Recordings

Run the security scan GitHub workflow.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: Existing tests cover the change and an absence of the polyfill issue will prove this fix is effective.
- [ ] I need help with writing tests

