### PR TITLE
fix: set hashlib's usedforsecurity=False to prevent weak hash

### DIFF
--- a/application/core/filters.py
+++ b/application/core/filters.py
@@ -193,7 +193,7 @@ def hash_file(filename):
         print("File not found when creating a hash: " + filename)
         return ""
 
-    sha1Hash = hashlib.sha1(content)
+    sha1Hash = hashlib.sha1(content, usedforsecurity=False)
     sha1Hashed = sha1Hash.hexdigest()
 
     # return the hex representation of digest


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR is for a security issue identified by the security scanner, a high priority issue related to the use of weak SHA-1 hashing for security purposes in our codebase. SHA-1 is considered insecure for cryptographic operations. SHA-1 is used in the codebase for cache-busting, which is not a security-sensitive task. To prevent the security scanner from flagging this as a vulnerability, we explicitly set `usedforsecurity=False` in all instances where SHA-1 is used for non-security tasks.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link: https://trello.com/c/ZjV6TnPG


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: The existing tests already validate the functionality affected by this change. Adding `usedforsecurity=False` doesn't change anything, so no new tests are needed.
- [ ] I need help with writing tests
