### PR TITLE
Refactor Makefile to copy GOVUK Frontend assets correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,8 @@ frontend:
 	make govukAssets
 	rsync -r assets/images static/
 	cp node_modules/maplibre-gl/dist/maplibre-gl.css static/stylesheets/maplibre-gl.css
-	cp -r node_modules/govuk-frontend/govuk/assets static/govuk
+	mkdir -p static/govuk/assets
+	cp -r node_modules/govuk-frontend/govuk/assets/* static/govuk/assets
 
 frontend-all: clean frontend
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Refactor Makefile to copy GOVUK Frontend assets correctly. Previously the assets were being copied into the `govuk` folder rather than `govuk/assets`.

## QA Instructions, Screenshots, Recordings

<img width="243" alt="Screenshot 2024-10-22 at 4 34 28 pm" src="https://github.com/user-attachments/assets/5c633254-e509-4146-840f-18187747cb88">

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?