### PR TITLE
Update min zoom

### DIFF
--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -66,7 +66,7 @@ export default class MapController {
 
     var map = new maplibregl.Map({
       container: this.mapId,
-      minZoom: 5.5,
+      minZoom: 6,
       maxZoom: 18,
       style: this.customStyleJson,
       maxBounds: [

--- a/assets/javascripts/MapController.js
+++ b/assets/javascripts/MapController.js
@@ -74,7 +74,7 @@ export default class MapController {
         [ 13, 57 ]
       ],
       center: viewFromUrl.centre || [ -1, 52.9 ],
-      zoom: viewFromUrl.zoom || 5.5,
+      zoom: viewFromUrl.zoom || 6,
       transformRequest: (url, resourceType) => {
         if(url.indexOf('api.os.uk') > -1){
           if(! /[?&]key=/.test(url) ) url += '?key=null'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [Bug Fix

## Description
The base map seems to disappear bellow a zoom level of 6. after spending two mornings looking I can't find any recent commits made, or anything local that would restrict this. 
my guess is os maps have done something to restrict this on their end

for now, ive updated our code, to set the min zoom level to 6. 

## QA Instructions, Screenshots, Recordings
deployed to dev and all seems to work now
https://www.development.digital-land.info/map
