### PR TITLE
Add terms and conditions, plus contact page

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -167,7 +167,7 @@ def add_base_routes(app):
     @app.get(
         "/terms-and-conditions", response_class=HTMLResponse, include_in_schema=False
     )
-    def accessibility_statement(request: Request):
+    def terms_and_conditions(request: Request):
         return templates.TemplateResponse(
             "pages/terms-and-conditions.html",
             {"request": request},

--- a/application/factory.py
+++ b/application/factory.py
@@ -164,6 +164,15 @@ def add_base_routes(app):
             {"request": request},
         )
 
+    @app.get(
+        "/terms-and-conditions", response_class=HTMLResponse, include_in_schema=False
+    )
+    def accessibility_statement(request: Request):
+        return templates.TemplateResponse(
+            "pages/terms-and-conditions.html",
+            {"request": request},
+        )
+
     @app.get("/service-status", response_class=HTMLResponse, include_in_schema=False)
     def service_status(request: Request):
         return templates.TemplateResponse(

--- a/application/templates/layouts/layout--about.html
+++ b/application/templates/layouts/layout--about.html
@@ -57,6 +57,12 @@
                 'href': sectionPath + 'performance',
                 'current': true if pageData.name == 'performance' else false,
                 'theme': theme,
+              },
+              {
+                'text': 'Contact',
+                'href': sectionPath + 'contact',
+                'current': true if pageData.name == 'contact' else false,
+                'theme': theme,
               }
             ],
         })

--- a/application/templates/pages/about/contact.html
+++ b/application/templates/pages/about/contact.html
@@ -1,0 +1,16 @@
+{% extends "layouts/layout--about.html" %}
+{% set templateName = 'dl-info/about/contact.html' %}
+{%- from "components/back-button/macro.jinja" import dlBackButton %}
+{%- block breadcrumbs -%}
+  {{ dlBackButton({
+    "parentHref": '/about/'
+  })}}
+{%- endblock -%}
+{%- do pageData.update({
+  'pageTitle': 'Contact',
+  'lede': lede
+}) %}
+{% block content_primary %}
+    {%- set page_content -%}{%- include pageData.root_url + "contact.md" -%}{%- endset -%}
+    {{ page_content | render_markdown }}
+{% endblock %}

--- a/application/templates/pages/about/contact.md
+++ b/application/templates/pages/about/contact.md
@@ -1,0 +1,3 @@
+If you’ve got a question, suggestion or need support, please contact us by emailing [digitalland@communities.gov.uk](mailto:digitalland@communities.gov.uk).
+
+We’re available from 9am until 5pm, Monday to Friday, except on public holidays. You’ll get a response within 5 working days.

--- a/application/templates/pages/cookies.html
+++ b/application/templates/pages/cookies.html
@@ -25,7 +25,7 @@
       <h1 class="govuk-heading-xl">Cookies on the Planning Data website</h1>
       <p class="govuk-body">The Planning Data website puts cookies onto your computer to collect information about how you browse the site. This helps us to:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>update and improve the website based on your needs</li>
+        <!-- <li>update and improve the website based on your needs</li> -->
         <li>remember the notifications you’ve seen so that we do not show them to you again</li>
       </ul>
       <p class="govuk-body">We do not collect any personal information that could be used to identify you.</p>
@@ -58,7 +58,7 @@
           </tr>
         </tbody>
       </table>
-      <h3 class="govuk-heading-m" id="google-analytics-cookies">Google Analytics cookies (optional)</h3>
+      <!-- <h3 class="govuk-heading-m" id="google-analytics-cookies">Google Analytics cookies (optional)</h3>
       <p class="govuk-body">We use Google Analytics to measure how you use the Planning Data website. This helps us to improve the website experience and make sure it’s meeting your needs.</p>
       <p class="govuk-body">Google Analytics sets cookies that store information about:</p>
       <ul class="govuk-list govuk-list--bullet">
@@ -98,7 +98,7 @@
             <td class="govuk-table__cell">10 minutes</td>
           </tr>
         </tbody>
-      </table>
+      </table> -->
 
       <!-- section for cookie options HTML -->
       <form id="cookie-form" class="govuk-form govuk-!-margin-top-9" onsubmit="return false;">

--- a/application/templates/pages/terms-and-conditions.html
+++ b/application/templates/pages/terms-and-conditions.html
@@ -1,0 +1,21 @@
+{% extends "layouts/layout.html" %}
+{% block pageTitle %}Terms and conditions - Planning Data{% endblock %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
+{%- from "components/back-button/macro.jinja" import dlBackButton %}
+{%- block breadcrumbs -%}
+    {{ dlBackButton({
+      "parentHref": '/'
+    })}}
+{%- endblock -%}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="app-prose">
+      {%- set page_content -%}{%- include "pages/terms-and-conditions.md" -%}{%- endset -%}
+      {{ page_content | render_markdown }}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/application/templates/pages/terms-and-conditions.md
+++ b/application/templates/pages/terms-and-conditions.md
@@ -134,3 +134,5 @@ If any of these terms and conditions are held to be invalid, unenforceable or il
 Please check these terms and conditions regularly. We can update them at any time without notice.
 
 You’ll agree to any changes if you continue to use the service after the terms and conditions have been updated.
+
+Last updated 15 January 2025.

--- a/application/templates/pages/terms-and-conditions.md
+++ b/application/templates/pages/terms-and-conditions.md
@@ -1,0 +1,136 @@
+# Terms and conditions
+
+This page and any pages it links to explain planning.data.gov.uk’s terms of use. You must agree to them to use planning.data.gov.uk.
+
+## Who we are
+
+planning.data.gov.uk is managed and operated by the Ministry of Housing, Communities and Local Government (MHCLG) and will be referred to as ‘we’ or ‘us’. planning.data.gov.uk and its connected web pages is ‘the service’.
+
+## Using the service
+
+You agree to use the service only for lawful purposes. You must also use it in a way that doesn’t infringe the rights of, or restrict or inhibit the use and enjoyment of the service by anyone else.
+
+We update the service all the time. We can change or remove content at any time without notice.
+
+Most content and data on the site is subject to Crown Copyright protection and is published under the [Open Government Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) (OGL), unless we indicate otherwise. Other content may be subject to copyright.
+
+Our logo is exempt from the OGL, except when it forms an integral part of a document or dataset.
+
+If any content isn’t subject to Crown Copyright protection or published under the OGL, we’ll usually credit the author or copyright holder.
+
+You can reproduce content published on our pages under the OGL as long as you follow the conditions of the OGL.
+
+[Contact us](https://www.planning.data.gov.uk/about/contact/) if you want to reproduce a piece of content but aren’t sure if it’s covered by Crown Copyright, the OGL or other copyright.
+
+We make most of the content on our pages available through [feeds](https://www.planning.data.gov.uk/docs) for other websites and applications to use. The websites and applications that use our feeds aren’t our products, and they might use versions of our content that have been edited and stored for later use (‘cached’).
+
+We don’t give any guarantees, conditions or warranties about the accuracy or completeness of any content used by these products. We’re not liable for any loss or damage that may come from your use of these products.
+
+The most up to date version of our content and data will always be on our service.
+
+## Linking to planning.data.gov.uk
+
+We welcome and encourage other websites to link to planning.data.gov.uk.
+
+You must contact us for permission if you want to:
+
+* charge your website’s users to click on a link to any page on the service  
+* say your website is associated with or endorsed by us or another government department or agency
+
+## Linking from planning.data.gov.uk
+
+planning.data.gov.uk contains links to websites that are managed by other government departments and agencies, local authorities, service providers and other organisations. These may be links to the original sources of the data. We do not have any control over the content of these websites. 
+
+We are not responsible for:  
+
+* the protection of any information that you provide to these websites  
+* any loss or damage that may come from your use of these websites, or any other websites they link to
+
+You agree to release us from any claims or disputes that may come from using these websites.  
+
+You should read the terms and conditions, privacy policies and end user licences that relate to these websites before you use them.  
+
+## Disclaimer
+
+While we make reasonable effort to keep our content and data up to date, we do n’t provide any guarantees, conditions or warranties that the information will be: 
+
+* current  
+* secure  
+* accurate  
+* complete  
+* free from bugs or viruses
+
+We’re not liable for any loss or damage that may come from using our content or data. This includes:
+
+* any direct, indirect or consequential losses  
+* any loss or damage caused by civil wrongs (‘tort’, including negligence), breach of contract or otherwise  
+* the use of our content or data and any websites that are linked to or from it  
+* the inability to use our content or data and any websites that are linked to or from it
+
+This applies if the loss or damage was foreseeable, arose in the normal course of things or you advised us that it might happen.
+
+This includes (but isn’t limited to) the loss of your:
+
+* income or revenue  
+* salary, benefits or other payments  
+* business  
+* profits or contracts  
+* opportunity  
+* anticipated savings  
+* data  
+* goodwill or reputation  
+* tangible property  
+* intangible property, including loss, corruption or damage to data or any computer system  
+* wasted management or office time
+
+We may still be liable for:
+
+* death or personal injury arising from our negligence  
+* fraudulent misrepresentation  
+* any other liability which cannot be excluded or limited under applicable law
+
+## Requests to remove content
+
+You can ask for content to be removed from our pages. We’ll only do this in certain cases, for example if it breaches copyright laws, contains sensitive personal data or material that may be considered obscene or defamatory.
+
+[Contact us](https://www.planning.data.gov.uk/contact/) to ask for content to be removed. You’ll need to send us the web address (URL) of the content and explain why you think it should be removed. We’ll reply to let you know whether we’ll remove it.
+
+We remove content at our discretion. You can still request information under the [Freedom of Information Act](https://www.gov.uk/make-a-freedom-of-information-request) and the [Data Protection Act](https://www.gov.uk/data-protection).
+
+## Information about you and your visits to our pages
+
+We may collect information about you in accordance with our [personal information charter](https://www.gov.uk/government/organisations/ministry-of-housing-communities-local-government/about/personal-information-charter) and our [cookie policy](https://www.planning.data.gov.uk/cookies). By using the site, you agree to us collecting this information and confirm that any data you provide is accurate.
+
+## Virus protection
+
+We make every effort to check and test our pages for viruses at every stage of production. You must make sure that the way you use our pages doesn’t expose you to the risk of viruses, malicious computer code or other forms of interference which can damage your computer system.
+
+We’re not responsible for any loss, disruption or damage to your data or computer system that might happen when you use our content or data.
+
+## Viruses, hacking and other offences
+
+When using our content or data, you must not introduce viruses, trojans, worms, logic bombs or any other material that’s malicious or technologically harmful.
+
+You must not try to gain unauthorised access to our content or data, the server on which it’s stored or any server, computer or database connected to it.
+
+You must not attack the site in any way. This includes denial-of-service attacks. We’ll report any attacks or attempts to gain unauthorised access to our servers to the relevant law enforcement authorities and share information about you with them.
+
+## Governing law
+
+These terms and conditions are governed by and construed in accordance with the laws of England and Wales.
+
+Any dispute you have which relates to these terms and conditions, or your use of the site (whether it be contractual or non-contractual), will be subject to the exclusive jurisdiction of the courts of England and Wales.
+
+## General
+
+We might decide not to exercise or enforce any right available to us under these terms and conditions. We can always decide to exercise or enforce that right at a later date.
+
+Doing this once won’t mean we automatically waive the right on any other occasion.
+
+If any of these terms and conditions are held to be invalid, unenforceable or illegal for any reason, the remaining terms and conditions will still apply.
+
+## Changes to these terms and conditions
+
+Please check these terms and conditions regularly. We can update them at any time without notice.
+
+You’ll agree to any changes if you continue to use the service after the terms and conditions have been updated.

--- a/application/templates/pages/terms-and-conditions.md
+++ b/application/templates/pages/terms-and-conditions.md
@@ -52,7 +52,7 @@ You should read the terms and conditions, privacy policies and end user licences
 
 ## Disclaimer
 
-While we make reasonable effort to keep our content and data up to date, we do n’t provide any guarantees, conditions or warranties that the information will be: 
+While we make reasonable effort to keep our content and data up to date, we don’t provide any guarantees, conditions or warranties that the information will be: 
 
 * current  
 * secure  

--- a/application/templates/partials/footer.html
+++ b/application/templates/partials/footer.html
@@ -8,6 +8,7 @@
             {"href": "/about/performance", "text": "Performance"},
             {"href": "/about/contact", "text": "Contact"},
             {"href": "/accessibility-statement", "text": "Accessibility statement"},
+            {"href": "/terms-and-conditions", "text": "Terms and conditions"},
         ],
         "html": 'Built by the <a href="https://www.gov.uk/government/organisations/ministry-of-housing-communities-local-government" class="govuk-footer__link">Ministry of Housing, Communities and Local Government</a>',
     }

--- a/application/templates/partials/footer.html
+++ b/application/templates/partials/footer.html
@@ -6,6 +6,7 @@
             {"href": "/service-status", "text": "Service status"},
             {"href": "/about/roadmap", "text": "Roadmap"},
             {"href": "/about/performance", "text": "Performance"},
+            {"href": "/about/contact", "text": "Contact"},
             {"href": "/accessibility-statement", "text": "Accessibility statement"},
         ],
         "html": 'Built by the <a href="https://www.gov.uk/government/organisations/ministry-of-housing-communities-local-government" class="govuk-footer__link">Ministry of Housing, Communities and Local Government</a>',

--- a/tests/accessibility/test_accessibility.py
+++ b/tests/accessibility/test_accessibility.py
@@ -78,5 +78,5 @@ def test_accessibility_of_the_roadmap_page(server_url):
 def test_accessibility_of_the_accessibility_statement_page(server_url):
     accessibility_test(server_url + "/accessibility-statement")
 
-def test_accessibility_of_the_accessibility_statement_page(server_url):
+def test_accessibility_of_the_terms_and_conditions_page(server_url):
     accessibility_test(server_url + "/terms-and-conditions")

--- a/tests/accessibility/test_accessibility.py
+++ b/tests/accessibility/test_accessibility.py
@@ -77,3 +77,6 @@ def test_accessibility_of_the_roadmap_page(server_url):
 
 def test_accessibility_of_the_accessibility_statement_page(server_url):
     accessibility_test(server_url + "/accessibility-statement")
+
+    def test_accessibility_of_the_accessibility_statement_page(server_url):
+    accessibility_test(server_url + "/terms-and-conditions")

--- a/tests/accessibility/test_accessibility.py
+++ b/tests/accessibility/test_accessibility.py
@@ -78,5 +78,5 @@ def test_accessibility_of_the_roadmap_page(server_url):
 def test_accessibility_of_the_accessibility_statement_page(server_url):
     accessibility_test(server_url + "/accessibility-statement")
 
-    def test_accessibility_of_the_accessibility_statement_page(server_url):
+def test_accessibility_of_the_accessibility_statement_page(server_url):
     accessibility_test(server_url + "/terms-and-conditions")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

This pull request adds a terms & conditions page, plus contact details. 

The terms & conditions have been checked by Government Legal Department. The terms make clear the conditions of use, that we do not accept any liability or provide any warranty for use of the data or the website, and that much of the data we index is provided by other sources. It also makes clear the licences and licence conditions associated with the data and the service.

These terms do not establish any service-level agreements for the API, but that is something we can do in future. 

Also introducing a Contact page, and have made changes to the Cookies page to make it more accurate.

## QA Instructions, Screenshots, Recordings

Available for checking on https://www.development.planning.data.gov.uk/

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why
- [ ] I need help with writing tests