### PR TITLE
Make clear which service we are

### DIFF
--- a/application/templates/pages/service-status.html
+++ b/application/templates/pages/service-status.html
@@ -27,7 +27,8 @@
     <p class="govuk-body">For live service status information you can view our dedicated <a href="https://service-status.planning.data.gov.uk/">service monitoring website</a>.</p>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" role="presentation">
     <h2 class="govuk-heading-m">Need to report a problem?</h2>
-    <p class="govuk-body">You can email: <a href="mailto:{{ templateVar.email }}">{{ templateVar.email }}</a></p>
+    <p class="govuk-body">This is the Planning Data service. If you're experiencing a problem with another government service, <a href="https://www.gov.uk/contact">visit GOV.UK</a> to find contact details for the relevant service.</p>
+    <p class="govuk-body">For problems with planning.data.gov.uk, you can email: <a href="mailto:{{ templateVar.email }}">{{ templateVar.email }}</a></p>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
We've had several emails from people trying to use Companies House services but getting 5XX errors. It turns out that if you google `companies house service status`, our service status page is the second result.

I've added some content to our service status page that hopefully makes it clear that we're the Planning Data service, and it points users to other contact routes if they've ended up in the wrong place.