### PR TITLE
Update links to document types finder in Dataset Editor

### DIFF
--- a/application/templates/pages/guidance/specifications/conservation-area.md
+++ b/application/templates/pages/guidance/specifications/conservation-area.md
@@ -1,4 +1,4 @@
-**Last updated: 16 January 2025**<br/>
+**Last updated: 3 April 2025**<br/>
 
 ---
 
@@ -219,7 +219,7 @@ Example: `http://www.LPAwebsite.org.uk/conservationarea1.pdf`
 
 ### document-type
 
-The code for the type of document this record refers to. Find the code you need using this [finder tool](https://dluhc-datasets.planning-data.dev/dataset/conservation-area-document-type/finder).
+The code for the type of document this record refers to. Find the code you need using this [finder tool](https://dataset-editor.planning.data.gov.uk/dataset/conservation-area-document-type/finder).
 
 ### notes
 

--- a/application/templates/pages/guidance/specifications/local-plan.md
+++ b/application/templates/pages/guidance/specifications/local-plan.md
@@ -1,4 +1,4 @@
-**Last updated: 10 December 2024**<br/>
+**Last updated: 3 April 2025**<br/>
 
 ---
 
@@ -261,7 +261,7 @@ Example: `Leeds-LP01`
 
 ### document-type
 
-The code for the type of document this record refers to. Find the code you need using this [finder tool.](https://dluhc-datasets.planning-data.dev/dataset/local-plan-document-type/finder)
+The code for the type of document this record refers to. Find the code you need using this [finder tool.](https://dataset-editor.planning.data.gov.uk/dataset/local-plan-document-type/finder)
 
 If you can’t see the code for the document type you need, let us know in this [GitHub discussion.](https://github.com/digital-land/data-standards-backlog/discussions/97)
 
@@ -359,7 +359,7 @@ Example: `Leeds-LP01`
 
 ### local-plan-event
 
-The code for the type of event this record refers to. Find the code you need using [this finder tool.](https://dluhc-datasets.planning-data.dev/dataset/local-plan-event/finder)
+The code for the type of event this record refers to. Find the code you need using [this finder tool.](https://dataset-editor.planning.data.gov.uk/dataset/local-plan-event/finder)
 
 Example: `estimated-plan-adoption-date`
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Following the [migration of dataset-editor](https://github.com/digital-land/technical-documentation/issues/319), this PR updates LPA-facing documentation to help them pick document type codes.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: No existing tests, but a broken links checker might help?
- [ ] I need help with writing tests
