### PR TITLE
cache `get_datasets_with_data_by_typology(sesssion, "geography")` calls

### DIFF
--- a/application/data_access/digital_land_queries.py
+++ b/application/data_access/digital_land_queries.py
@@ -62,6 +62,11 @@ def get_datasets_with_data_by_typology(
     return [DatasetModel.from_orm(ds) for ds in datasets]
 
 
+@session_cache("datasets-typology-geo")
+def get_datasets_with_data_by_geography(session: Session) -> List[DatasetModel]:
+    return get_datasets_with_data_by_typology(session, "geography")
+
+
 def get_typologies(session: Session) -> List[TypologyModel]:
     typologies = session.query(TypologyOrm).order_by(TypologyOrm.typology).all()
     return [TypologyModel.from_orm(t) for t in typologies]

--- a/application/routers/map_.py
+++ b/application/routers/map_.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from application.settings import get_settings
 from application.core.templates import templates
 from application.data_access.digital_land_queries import (
-    get_datasets_with_data_by_typology,
+    get_datasets_with_data_by_geography,
 )
 from application.db.session import get_session
 
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 @router.get("/", response_class=HTMLResponse)
 def get_map(request: Request, session: Session = Depends(get_session)):
     settings = get_settings()
-    geography_datasets = get_datasets_with_data_by_typology(session, "geography")
+    geography_datasets = get_datasets_with_data_by_geography(session)
     return templates.TemplateResponse(
         "national-map.html",
         {"request": request, "layers": geography_datasets, "settings": settings},

--- a/tests/integration/test_digital_land_queries.py
+++ b/tests/integration/test_digital_land_queries.py
@@ -75,7 +75,13 @@ def test_get_datasets_with_data_by_geography(db_session):
         dataset="cached-test-dataset",
         typology="geography",
     )
+    entity = EntityOrm(
+        entity=1,
+        dataset="cached-test-dataset",
+        typology="geography",
+    )
     db_session.add(dataset)
+    db_session.add(entity)
 
     datasets1 = get_datasets_with_data_by_geography(db_session)
     assert len(datasets1) == 1

--- a/tests/integration/test_digital_land_queries.py
+++ b/tests/integration/test_digital_land_queries.py
@@ -1,5 +1,6 @@
 from application.data_access.digital_land_queries import (
     get_datasets_with_data_by_typology,
+    get_datasets_with_data_by_geography,
 )
 from application.db.models import DatasetOrm, EntityOrm
 
@@ -64,3 +65,15 @@ def test_get_datasets_with_data_by_typology_does_not_find_if_no_entities_exist(
     datasets = get_datasets_with_data_by_typology(db_session, "geography")
 
     assert len(datasets) == 0
+
+
+def test_get_datasets_with_data_by_geography(db_session):
+    dataset = DatasetOrm(
+        dataset="test-dataset",
+        typology="geography",
+    )
+    db_session.add(dataset)
+
+    datasets = get_datasets_with_data_by_geography(db_session)
+
+    assert len(datasets) == 1

--- a/tests/integration/test_digital_land_queries.py
+++ b/tests/integration/test_digital_land_queries.py
@@ -3,6 +3,7 @@ from application.data_access.digital_land_queries import (
     get_datasets_with_data_by_geography,
 )
 from application.db.models import DatasetOrm, EntityOrm
+from application.db.session import SESSION_CACHE
 
 
 def test_get_datasets_with_data_by_typology_finds_if_typology_correct_and_entities_exist(
@@ -68,12 +69,16 @@ def test_get_datasets_with_data_by_typology_does_not_find_if_no_entities_exist(
 
 
 def test_get_datasets_with_data_by_geography(db_session):
+    SESSION_CACHE.clear()
+
     dataset = DatasetOrm(
-        dataset="test-dataset",
+        dataset="cached-test-dataset",
         typology="geography",
     )
     db_session.add(dataset)
 
-    datasets = get_datasets_with_data_by_geography(db_session)
+    datasets1 = get_datasets_with_data_by_geography(db_session)
+    assert len(datasets1) == 1
 
-    assert len(datasets) == 1
+    datasets2 = get_datasets_with_data_by_geography(db_session)
+    assert datasets1[0] == datasets2[0]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

Another easy performance win for frequently visited page: the `get_datasets_with_data_by_typology` (always called with "geography" param).

## Related Tickets & Documents

- Closes #383 

## ~~QA Instructions, Screenshots, Recordings~~


## Added/updated tests?

- [x] Yes

