### PR TITLE
Fix broken entity linking

### DIFF
--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -157,7 +157,7 @@ def lookup_entity_link(
     """
     search_params = {"reference": [reference], "dataset": [dataset]}
 
-    if organisation_entity is not None:
+    if dataset != "listed-building" and organisation_entity is not None:
         search_params["organisation_entity"] = [organisation_entity]
 
     found_entities = get_entity_search(session, search_params)

--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -157,8 +157,8 @@ def lookup_entity_link(
     """
     search_params = {"reference": [reference], "dataset": [dataset]}
 
-    # For most fields, we search for linked entities using dataset, reference and organisation
-    # However, for listed-building, we need to search the Historic England data so we remove the organisation restriction
+    # Normally we filter by dataset, reference, and organisation.
+    # For 'listed-building', we exclude organisation to match Historic England data.
     if dataset != "listed-building" and organisation_entity is not None:
         search_params["organisation_entity"] = [organisation_entity]
 

--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -157,6 +157,8 @@ def lookup_entity_link(
     """
     search_params = {"reference": [reference], "dataset": [dataset]}
 
+    # For most fields, we search for linked entities using dataset, reference and organisation
+    # However, for listed-building, we need to search the Historic England data so we remove the organisation restriction
     if dataset != "listed-building" and organisation_entity is not None:
         search_params["organisation_entity"] = [organisation_entity]
 

--- a/application/routers/entity.py
+++ b/application/routers/entity.py
@@ -161,6 +161,8 @@ def handle_entity_response(
         "local-plan-boundary",
         "local-plan",
         "local-plan-event",
+        "conservation-area",
+        "listed-building",
     ]
 
     linked_entities = {}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We have noticed that entity linking for Conservation Areas and Listed Buildings is not working as expected. For Conservation Areas, this is because the field was not added to the EntityLinkField list.

For Listed Buildings, a code change to the function was required in order to bypass the organisation check that was brought in via #388. We need to continue to limit by organisation for all other datasets, but for Listed Building it must search for the correct LB from the Historic England data (which has a different organisation). For ease, I have changed to code to only search by reference and dataset for listed building. This represents minimal risk as the only source of listed building data is Historic England - however, we may want to refactor this code at a later date to remove the hardcoding of datasets.

## Related Tickets & Documents

- Related Issue https://github.com/digital-land/digital-land.info/issues/417

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
