### PR TITLE
Revert listed building dataset name

### DIFF
--- a/application/templates/pages/guidance/specifications/listed-building.md
+++ b/application/templates/pages/guidance/specifications/listed-building.md
@@ -1,4 +1,4 @@
-**Last updated: 6 August 2025**<br/>
+**Last updated: 7 August 2025**<br/>
 
 ---
 
@@ -38,7 +38,7 @@ For example:
 
 These are all valid, and any uppercase characters will be converted to lowercase.
 
-Listed building related area dataset
+Listed building outline dataset
 ------------------------
 
 This dataset is about buildings listed on the National Heritage List for England because of their historical or architectural importance.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Reverts the name of the dataset but retains the updates to guidance. Other work to change names elsewhere needs to be raised at the same time, so that dataset names are consistent across the board. However, the updates to the guidance should address problems that data providers have faced in understanding how to prepare and provide data to the specification.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _Static content, no tests needed_
- [ ] I need help with writing tests