### PR TITLE
Make consistent with technical specification

### DIFF
--- a/application/templates/pages/guidance/specifications/listed-building.md
+++ b/application/templates/pages/guidance/specifications/listed-building.md
@@ -66,7 +66,7 @@ Example: `10 and 12, Lower Clapton Road E5`
 
 ### geometry
 
-The listed building and any related area geometry as a single polygon or multipolygon value. All points in the polygon must be in the WGS84 coordinate reference system.
+The listed building and any related area geometry as a single polygon or multipolygon value. Use [curtilage](https://historicengland.org.uk/images-books/publications/listed-buildings-and-curtilage-advice-note-10/) (according to the Historic England advice note) if it’s available. This is the boundary of the area to be considered for planning purposes. All points in the polygon must be in the WGS84 coordinate reference system.
 
 If you’re providing geometry in a CSV, geometry should be in well-known text (WKT).
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

We get a lot of questions about whether to include curtilage or not, which is addressed in the technical specification but not the dataset guidance. This PR brings the dataset guidance in line with the technical specification, which refers to curtilage as the expected related area geometry.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: It's a static page
- [ ] I need help with writing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated listed building guidance: expanded geometry section to allow use of curtilage-based boundaries where available, with a clear statement that the geometry represents the boundary for planning purposes.
  * Clarified that polygons/multipolygons must use the WGS84 coordinate reference system.
  * CSV-related guidance remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->