### PR TITLE
Add JSON-LD for Dataset to improve discoverability

### DIFF
--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -8,6 +8,40 @@
 
 {% block headStart %}
   <meta name="generated-date" content="{{ now }}"/>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      "name": {{ dataset["name"]|tojson }},
+      "description": {{ dataset["text"]|default('')|striptags|trim|tojson}},
+      "url": {{ ("https://planning.data.gov.uk/dataset/" ~ dataset["dataset"])|tojson }},
+      "license": {{ dataset["licence_text"]|default('')|tojson}},
+      "isAccessibleForFree": true,
+      "creator": {
+        "@type": "Organization",
+        "name": "Ministry of Housing, Communities and Local Government",
+        "url": "https://www.gov.uk/government/organisations/ministry-of-housing-communities-local-government"
+      },
+      "distribution": [
+        {
+          "@type": "DataDownload",
+          "encodingFormat": "CSV",
+          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.csv')|tojson}},
+        },
+        {
+          "@type": "DataDownload",
+          "encodingFormat": "JSON",
+          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.json')|tojson}}
+        }{% if dataset['typology'] == 'geography' %},
+        {
+          "@type": "DataDownload",
+          "encodingFormat": "GeoJSON",
+          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.geojson')|tojson}}
+        }
+        {% endif %}
+      ]
+    }
+  </script>
 {% endblock headStart %}
 
 {%- block breadcrumbs -%}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds structured data (in JSON-LD format) to a dataset page according to the Schema.org [Dataset definition](https://developers.google.com/search/docs/appearance/structured-data/dataset) for consumption by Google and other search engines. It will help with dataset discovery.

## QA Instructions, Screenshots, Recordings

Need to check that this produces valid JSON-LD. I don't think the licence will be produced in a valid way, meaning we might need to add a `url` field to the [licence dataset](https://datasette.planning.data.gov.uk/digital-land/licence).  

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
