### PR TITLE
Fix JSON-LD dataset schema

### DIFF
--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -25,17 +25,17 @@
       "distribution": [
         {
           "@type": "DataDownload",
-          "encodingFormat": "CSV",
+          "encodingFormat": "text/csv",
           "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.csv')|tojson}}
         },
         {
           "@type": "DataDownload",
-          "encodingFormat": "JSON",
+          "encodingFormat": "application/json",
           "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.json')|tojson}}
         }{% if dataset['typology'] == 'geography' %},
         {
           "@type": "DataDownload",
-          "encodingFormat": "GeoJSON",
+          "encodingFormat": "application/geo+json",
           "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.geojson')|tojson}}
         }
         {% endif %}

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -12,7 +12,7 @@
     {
       "@context": "https://schema.org",
       "@type": "Dataset",
-      "name": {{ (dataset["plural"] if dataset.get("plural") else dataset["name"])|tojson }},
+      "name": {{ dataset["name"]|tojson }},
       "description": {{ dataset["text"]|default('')|strip_markdown|striptags|trim|tojson }},
       "url": {{ ("https://planning.data.gov.uk/dataset/" ~ dataset["dataset"])|tojson }},
       "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -13,7 +13,7 @@
       "@context": "https://schema.org",
       "@type": "Dataset",
       "name": {{ dataset["plural"]|tojson }},
-      "description": {{ dataset["text"]|default('')|striptags|trim|tojson}},
+      "description": {{ dataset["text"]|default('')|strip_markdown|striptags|trim|tojson}},
       "url": {{ ("https://planning.data.gov.uk/dataset/" ~ dataset["dataset"])|tojson }},
       "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
       "isAccessibleForFree": true,

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -12,7 +12,7 @@
     {
       "@context": "https://schema.org",
       "@type": "Dataset",
-      "name": {{ dataset["name"]|tojson }},
+      "name": {{ dataset["plural"]|tojson }},
       "description": {{ dataset["text"]|default('')|striptags|trim|tojson}},
       "url": {{ ("https://planning.data.gov.uk/dataset/" ~ dataset["dataset"])|tojson }},
       "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -12,7 +12,7 @@
     {
       "@context": "https://schema.org",
       "@type": "Dataset",
-      "name": {{ dataset["name"]|tojson }},
+      "name": {{ (dataset["plural"] if dataset.get("plural") else dataset["name"])|tojson }},
       "description": {{ dataset["text"]|default('')|strip_markdown|striptags|trim|tojson }},
       "url": {{ ("https://planning.data.gov.uk/dataset/" ~ dataset["dataset"])|tojson }},
       "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -12,7 +12,7 @@
     {
       "@context": "https://schema.org",
       "@type": "Dataset",
-      "name": {{ dataset["plural"]|tojson }},
+      "name": {{ (dataset["plural"] if dataset.get("plural") else dataset["name"])|tojson }},
       "description": {{ dataset["text"]|default('')|strip_markdown|striptags|trim|tojson }},
       "url": {{ ("https://planning.data.gov.uk/dataset/" ~ dataset["dataset"])|tojson }},
       "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -37,7 +37,7 @@
           "@type": "DataDownload",
           "encodingFormat": "application/geo+json",
           "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.geojson')|tojson}}
-        }{% endif %}
+        } {% endif %}
       ]
     }
   </script>

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -37,8 +37,7 @@
           "@type": "DataDownload",
           "encodingFormat": "application/geo+json",
           "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.geojson')|tojson}}
-        }
-        {% endif %}
+        }{% endif %}
       ]
     }
   </script>

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -26,7 +26,7 @@
         {
           "@type": "DataDownload",
           "encodingFormat": "CSV",
-          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.csv')|tojson}},
+          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.csv')|tojson}}
         },
         {
           "@type": "DataDownload",

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -13,7 +13,7 @@
       "@context": "https://schema.org",
       "@type": "Dataset",
       "name": {{ dataset["plural"]|tojson }},
-      "description": {{ dataset["text"]|default('')|strip_markdown|striptags|trim|tojson}},
+      "description": {{ dataset["text"]|default('')|strip_markdown|striptags|trim|tojson }},
       "url": {{ ("https://planning.data.gov.uk/dataset/" ~ dataset["dataset"])|tojson }},
       "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
       "isAccessibleForFree": true,
@@ -26,17 +26,17 @@
         {
           "@type": "DataDownload",
           "encodingFormat": "text/csv",
-          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.csv')|tojson}}
+          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.csv')|tojson }}
         },
         {
           "@type": "DataDownload",
           "encodingFormat": "application/json",
-          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.json')|tojson}}
+          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.json')|tojson }}
         }{% if dataset['typology'] == 'geography' %},
         {
           "@type": "DataDownload",
           "encodingFormat": "application/geo+json",
-          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.geojson')|tojson}}
+          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.geojson')|tojson }}
         } {% endif %}
       ]
     }


### PR DESCRIPTION
Adds some fixes after running the development pages through [Rich Results Test](https://search.google.com/test/rich-results).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Descriptions now strip markdown and HTML, then trimmed and encoded for cleaner JSON‑LD.
  * Corrected download MIME types to text/csv, application/json and application/geo+json for better compatibility.
  * Download URLs are now output safely and consistently (no trailing commas).
  * Minor template formatting tweaks and conditional handling for geographic downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->