### PR TITLE
Fix JSON-LD dataset schema

### DIFF
--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -37,8 +37,7 @@
           "@type": "DataDownload",
           "encodingFormat": "GeoJSON",
           "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.geojson')|tojson}}
-        }
-        {% endif %}
+        }{% endif %}
       ]
     }
   </script>

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -12,7 +12,7 @@
     {
       "@context": "https://schema.org",
       "@type": "Dataset",
-      "name": {{ dataset["name"]|tojson }},
+      "name": {{ dataset["plural"]|tojson }},
       "description": {{ dataset["text"]|default('')|striptags|trim|tojson}},
       "url": {{ ("https://planning.data.gov.uk/dataset/" ~ dataset["dataset"])|tojson }},
       "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -13,7 +13,7 @@
       "@context": "https://schema.org",
       "@type": "Dataset",
       "name": {{ dataset["plural"]|tojson }},
-      "description": {{ dataset["text"]|default('')|striptags|trim|tojson}},
+      "description": {{ dataset["text"]|default('')|render_markdown|striptags|trim|tojson }},
       "url": {{ ("https://planning.data.gov.uk/dataset/" ~ dataset["dataset"])|tojson }},
       "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
       "isAccessibleForFree": true,

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -26,7 +26,7 @@
         {
           "@type": "DataDownload",
           "encodingFormat": "CSV",
-          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.csv')|tojson}},
+          "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.csv')|tojson}}
         },
         {
           "@type": "DataDownload",

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -25,17 +25,17 @@
       "distribution": [
         {
           "@type": "DataDownload",
-          "encodingFormat": "CSV",
+          "encodingFormat": "text/csv",
           "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.csv')|tojson}}
         },
         {
           "@type": "DataDownload",
-          "encodingFormat": "JSON",
+          "encodingFormat": "application/json",
           "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.json')|tojson}}
         }{% if dataset['typology'] == 'geography' %},
         {
           "@type": "DataDownload",
-          "encodingFormat": "GeoJSON",
+          "encodingFormat": "application/geo+json",
           "contentUrl": {{ (data_file_url ~ '/dataset/' ~ dataset["dataset"] ~ '.geojson')|tojson}}
         }{% endif %}
       ]


### PR DESCRIPTION
Adds some fixes after running the JSON-LD through Rich Results Test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Structured data now uses the pluralised dataset name and renders descriptions with markdown processing for richer, more accurate metadata.

- Bug Fixes
  - Fixed invalid JSON in the DataDownload schema by removing an extraneous comma, ensuring schema markup parses correctly across consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->