### PR TITLE
Add noindex to fact pages

### DIFF
--- a/application/templates/fact-search.html
+++ b/application/templates/fact-search.html
@@ -3,6 +3,10 @@
 
 {%- from "components/summary-card/macro.jinja" import appSummaryCard %}
 
+{% block headStart %}
+  <meta name="robots" content="noindex">
+{% endblock headStart %}
+
 {% block content %}
   <main id="content" role="main">
     <section class="govuk-width-container govuk-!-padding-bottom-6">

--- a/application/templates/fact.html
+++ b/application/templates/fact.html
@@ -10,6 +10,10 @@
 
 {%- block pageTitle %}{{ row_name }} | {{ dataset.name }} | Planning Data{% endblock -%}
 
+{% block headStart %}
+  <meta name="robots" content="noindex">
+{% endblock headStart %}
+
 {%- from "components/back-button/macro.jinja" import dlBackButton %}
 {%- block breadcrumbs -%}
   {{ dlBackButton({


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This will allow robots and other web spiders to deindex fact pages from their search results. Fact pages are not that useful and add a lot of noise to search results.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: Not needed
- [ ] I need help with writing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Implemented noindex metadata on the Fact Search and Fact pages. Impact: these pages will no longer appear in external search engine results, reducing their visibility outside the application while remaining fully accessible within it.
  - No changes to page layout, content, or user workflows; behaviour within the app remains unchanged.
  - Minor template updates only; no impact on performance or accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->