### PR TITLE
Noindex when there are query params

### DIFF
--- a/application/templates/search.html
+++ b/application/templates/search.html
@@ -20,7 +20,7 @@
 
 {% block headStart %}
   {{ super() }}
-  {% if query.params %}
+  {% if url_query_params.str != "" %}
     <meta name="robots" content="noindex">
   {% endif %}
 {% endblock headStart %}

--- a/application/templates/search.html
+++ b/application/templates/search.html
@@ -18,6 +18,13 @@
   {{ super() }}
 {% endblock -%}
 
+{% block headStart %}
+  {{ super() }}
+  {% if query.params %}
+    <meta name="robots" content="noindex">
+  {% endif %}
+{% endblock headStart %}
+
 {% block breadcrumbs %}
   {{ dlBackButton({
     "parentHref": '/'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

If the user searches for something on the search page, or uses any filters or facets, do not allow search engines to index the resulting page.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: Not needed
- [ ] I need help with writing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a meta robots "noindex" tag to search results pages when query parameters are present to improve SEO hygiene by preventing parameterised results from being indexed.
  - Implemented in the page head while preserving existing head content; no changes to layout, breadcrumbs, or user-facing behaviour.
  - Reduces duplicate content exposure in search engines without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->