### PR TITLE
Added text descriptions when no results for map, organisation, entity and datasets are found.

### DIFF
--- a/application/templates/components/find-an-area-form/macro.jinja
+++ b/application/templates/components/find-an-area-form/macro.jinja
@@ -40,7 +40,13 @@
       {% elif search_result.get("type") == "uprn" and search_result.get("result") %}
         Showing results for UPRN: {{ search_result.get("result", {}).get("UPRN", {}) }}
       {% else %}
-        No results found for {{ search_query }}
+        No results found for '{{ search_query }}'.
+      </p>
+      <p class="govuk-body">
+        Check <a href=https://design.planning.data.gov.uk/what-we-are-working-on>our current priorities</a> to see if this data is being prepared for the platform.
+      </p>
+      <p class="govuk-body">
+        If it's not there, you can <a href=https://design.planning.data.gov.uk/get-involved-in-designing-data>contribute to our data design process</a> to help prioritise it.
       {% endif %}
     </p>
   </div>

--- a/application/templates/dataset_index.html
+++ b/application/templates/dataset_index.html
@@ -76,6 +76,17 @@
 	{% endif %}
 	{% endfor %}
 
-	<p class="dl-list-filter__no-filter-match">No dataset matches that filter.</p>
+	<div class="dl-list-filter__no-filter-match js-hidden">
+		<p class="govuk-body">No dataset matches <span class="js-search-term-display"></span>.</p>
+		<p class="govuk-body">
+			Check <a href="https://design.planning.data.gov.uk/what-we-are-working-on">our current priorities</a> to see if
+			this data is being prepared for the platform.
+		</p>
+		<p class="govuk-body">
+			If it's not there, you can <a
+				href="https://design.planning.data.gov.uk/get-involved-in-designing-data">contribute to our data design
+				process</a> to help prioritise it.
+		</p>
+	</div>
 
 {% endblock %}

--- a/application/templates/organisation_index.html
+++ b/application/templates/organisation_index.html
@@ -71,6 +71,19 @@
   </div>
   {% endfor %}
 
+  <div class="dl-list-filter__no-filter-match js-hidden">
+		<p class="govuk-body">No dataset matches <span class="js-search-term-display"></span>.</p>
+		<p class="govuk-body">
+			Check <a href="https://design.planning.data.gov.uk/what-we-are-working-on">our current priorities</a> to see if
+			this data is being prepared for the platform.
+		</p>
+		<p class="govuk-body">
+			If it's not there, you can <a
+				href="https://design.planning.data.gov.uk/get-involved-in-designing-data">contribute to our data design
+				process</a> to help prioritise it.
+		</p>
+	</div>
+
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
   <h2 class="govuk-heading-s govuk-!-margin-bottom-0" id="download-the-data">

--- a/application/templates/search.html
+++ b/application/templates/search.html
@@ -274,7 +274,19 @@
 
         </div>
         <!-- /.app-results-body -->
-
+        {% elif count == 0 %}
+        <div class="app-results-body">
+          <p class="govuk-body">No results found</p>
+          <p class="govuk-body">
+            Check <a href="https://design.planning.data.gov.uk/what-we-are-working-on">our current priorities</a> to see if
+            this data is being prepared for the platform.
+          </p>
+          <p class="govuk-body">
+            If it's not there, you can <a href="https://design.planning.data.gov.uk/get-involved-in-designing-data">contribute
+              to our data design
+              process</a> to help prioritise it.
+          </p>
+        </div>
         {% endif %}
       </div>
       <!-- /.govuk-grid-column-two-thirds -->
@@ -302,5 +314,5 @@
 </script>
 
 
-{% endblock pageScripts %}
 
+{% endblock pageScripts %}

--- a/assets/javascripts/ListFilter.js
+++ b/assets/javascripts/ListFilter.js
@@ -50,7 +50,7 @@ export class ListFilter{
             item.classList.add('js-hidden');
           });
 
-        this.updateListCounts(listsToFilter);
+        this.updateListCounts(listsToFilter, searchTerm);
     }
 
     termToMatchOn(item){
@@ -76,7 +76,7 @@ export class ListFilter{
         return false
     }
 
-    updateListCounts(lists){
+    updateListCounts(lists, searchTerm = ''){
         var totalMatches = 0;
         const list_section_selector = this.list_section_selector;
         const count_wrapper_selector = this.count_wrapper_selector;
@@ -102,8 +102,15 @@ export class ListFilter{
 
         // if no results show message
         if (this.$noMatches) {
+          const $searchTermDisplay = this.$noMatches.querySelector('.js-search-term-display');
           if (totalMatches === 0) {
             this.$noMatches.classList.remove('js-hidden');
+            // Update the search term display
+            if ($searchTermDisplay && searchTerm.trim()) {
+              $searchTermDisplay.textContent = `'${searchTerm}'`;
+            } else if ($searchTermDisplay) {
+              $searchTermDisplay.textContent = '';
+            }
           } else {
             this.$noMatches.classList.add('js-hidden');
           }


### PR DESCRIPTION
Empty Dataset Search Result

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Added empty search pages as shown in https://app.mural.co/t/mhclg2837/m/mhclg2837/1746625606138/2a1986a26eeb2b8c97c568a6d57417b31df58767?wid=1-1756817080428

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Closes https://github.com/digital-land/digital-land/issues/451

## QA Instructions, Screenshots, Recordings

Have been unable to load some of the datasets on my local machine, so might need to check when searching in the four pages with live data 

https://www.planning.data.gov.uk/map/
https://www.planning.data.gov.uk/dataset/
https://www.planning.data.gov.uk/entity/
https://www.planning.data.gov.uk/organisation/

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: 
I don't believe these mostly visual changes have test requirements. 
- [ ] I need help with writing tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer “no results” messages across search, dataset, and organisation listings.
  - The searched term is now shown in quotes within no-match messages.
  - Added helpful guidance with links to current priorities and how to contribute to data design when no matches are found.
  - No-match notices are revealed dynamically when filters return zero results, improving feedback and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->