### PR TITLE
Add JSON link to Organisations page

### DIFF
--- a/application/templates/organisation_index.html
+++ b/application/templates/organisation_index.html
@@ -76,5 +76,5 @@
   <h2 class="govuk-heading-s govuk-!-margin-bottom-0" id="download-the-data">
     Download the data
   </h2>
-  <p class="govuk-hint govuk-!-font-size-14">You can take a copy of this data as <a class="govuk-link" href="{{ data_file_url }}/organisation-collection/dataset/organisation.csv">CSV</a> and <a class="govuk-link" href="{{ data_file_url }}/organisation-collection/dataset/organisation.json">JSON</a>.</p>
+  <p class="govuk-hint govuk-!-font-size-14">You can take a copy of this data as <a class="govuk-link" href="{{ data_file_url }}/organisation-collection/dataset/organisation.csv">CSV</a> and <a class="govuk-link" href="/organisation.json">JSON</a>.</p>
 {% endblock %}

--- a/application/templates/organisation_index.html
+++ b/application/templates/organisation_index.html
@@ -76,5 +76,5 @@
   <h2 class="govuk-heading-s govuk-!-margin-bottom-0" id="download-the-data">
     Download the data
   </h2>
-  <p class="govuk-hint govuk-!-font-size-14">You can take a copy of this data as <a class="govuk-link" href="{{ data_file_url }}/organisation-collection/dataset/organisation.csv">CSV</a>.</p>
+  <p class="govuk-hint govuk-!-font-size-14">You can take a copy of this data as <a class="govuk-link" href="{{ data_file_url }}/organisation-collection/dataset/organisation.csv">CSV</a> and <a class="govuk-link" href="{{ data_file_url }}/organisation-collection/dataset/organisation.json">JSON</a>.</p>
 {% endblock %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adds a link to download the organisations data as JSON.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: Small addition
- [ ] I need help with writing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a JSON download option for organisation data alongside the existing CSV download.
  * Updated the download text to clearly indicate availability of both CSV and JSON formats.
  * Included a direct link to the JSON file while retaining the CSV link.
  * No changes to page structure or other behaviours; existing CSV functionality remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->