### PR TITLE
Add warning text for "Planning application" datasets

### DIFF
--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -51,15 +51,12 @@
 
 {% block content %}
 
-{% if dataset["name"] == "Planning application" %}
-  {% include 'partials/planning-application-banner.html' %}
-{% endif %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-xl">Dataset</span>
       <h1 class="govuk-heading-xl">{{ dataset["name"] }}</h1>
       {% if dataset_coverage_status != "full" %}
-        {% include 'partials/data-coverage-banner.html' %}
+        {% include 'partials/planning-application-banner.html' %}
       {% endif %}
     </div>
   </div>

--- a/application/templates/partials/planning-application-banner.html
+++ b/application/templates/partials/planning-application-banner.html
@@ -1,7 +1,11 @@
-<div class="govuk-warning-text">
-	<span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-	<strong class="govuk-warning-text__text">
-		<span class="govuk-visually-hidden">Warning</span>
-		The {{ dataset["name"]|lower }} dataset is incomplete and is not yet ready for use. You can <a class="govuk-link" href="https://design.planning.data.gov.uk/project/planning-applications" rel="noopener noreferrer">contribute to its development</a>.
-	</strong>
+<div class="govuk-warning-text" id="dl-data-coverage-banner">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-visually-hidden">Warning</span>
+    {% if dataset["name"] == "Planning application" %}
+      The {{ dataset["name"]|lower }} dataset is incomplete and is not yet ready for use. You can <a class="govuk-link" href="https://design.planning.data.gov.uk/project/planning-applications" rel="noopener noreferrer">contribute to its development</a>.
+    {% else %}
+      The data may be incomplete and not yet cover all of England. We're working to improve its availability and quality.
+    {% endif %}
+  </strong>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Add a warning text when viewing "Planning applications" dataset

## Related Tickets & Documents

- [Ticket Link](https://github.com/orgs/digital-land/projects/13/views/6?pane=issue&itemId=131815000&issue=digital-land%7Cdigital-land%7C471)


## QA Instructions, Screenshots, Recordings

Go to:
https://www.development.planning.data.gov.uk/dataset/planning-application
And you should see the warning message:
> The planning application dataset is incomplete and is not yet ready for use. You can [contribute to its development](https://design.planning.data.gov.uk/project/planning-applications).

This warning message is only visible if the Dataset is "Planning application" if you chose a different Dataset you will see a different warning message.

And you should see the warning text, however if you choose a different  dataset that warning will not be visible.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Small addition
- [ ] I need help with writing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a planning application warning banner that displays on relevant datasets, providing users with information about data availability and offering a link to contribute to dataset completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->