### PR TITLE
518 Fix `cookiePrefs` Reference error by declaring cookie functions globally

### DIFF
--- a/application/templates/layouts/base.html
+++ b/application/templates/layouts/base.html
@@ -68,6 +68,9 @@
   {% block bodyScripts %}
     <script type="module">
       import {showCookieBannerIfNotSetAndSetTrackingCookies, cookiePrefs} from "{{ cacheBust(assetPath | default('/assets') + '/javascripts/cookies.js') }}";
+      // Expose module symbols globally to allow inline `onclick` handlers to use them
+      window.cookiePrefs = cookiePrefs;
+      window.showCookieBannerIfNotSetAndSetTrackingCookies = showCookieBannerIfNotSetAndSetTrackingCookies;
       showCookieBannerIfNotSetAndSetTrackingCookies();
       cookiePrefs.get();
     </script>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes cookies being accepted or rejected.

## Related Tickets & Documents
- [Ticket Link](https://github.com/orgs/digital-land/projects/13/views/9?pane=issue&itemId=138305258&issue=digital-land%7Cdigital-land%7C518)


## QA Instructions, Screenshots, Recordings

First make sure the issue still happens by following the next steps in Production:

- Go to https://www.planning.data.gov.uk/cookies
- Scroll to the bottom of the page where you can find the cookies radio buttons
- Open your browser "inspect element" console
- Select the "Application" tab and click on "cookies" to make sure its empty, if its not, empty it
- Lastly select either "Use cookies that measure my website use" or "Do not use cookies that measure my website use" and you will see that the "cookies" are not being set (you can see nothing is set in the browser "inspect element" console)

Now go to to Dev and repeat the steps above to see it working

No cookies in browser memory.
<img width="1411" height="999" alt="Screenshot from 2025-11-12 15-37-46" src="https://github.com/user-attachments/assets/914398c4-10ab-4288-a576-5ab34b990ccd" />

Selected "Do not use cookies that measure my website use" and we can now see that cookies have been set in the browser memory to {"essential":true,"settings":false,"usage":false,"campaigns":false} the important parts here are "essential" and "usage" which are set to False
<img width="1411" height="1038" alt="Screenshot from 2025-11-12 15-38-11" src="https://github.com/user-attachments/assets/1c70180c-b231-4bb6-bcf1-c27b9228b529" />

Selected "Use cookies that measure my website use" and clicked on "Datasets", we can now see that cookies have been set in the browser memory to {"essential":true,"settings":false,"usage":true,"campaigns":false} the important parts here are "essential" and "usage" which have been set to True.
We can now also see that Google Analytics sets its cookies correctly as a result.
<img width="1411" height="1038" alt="Screenshot from 2025-11-12 15-41-52" src="https://github.com/user-attachments/assets/3e107bd6-fa0a-4bd5-8b33-7c93106c8205" />


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: Simple JS global declaration was forgotten
- [ ] I need help with writing tests
