### PR TITLE
529 Implement entity quality field 

### DIFF
--- a/application/core/utils.py
+++ b/application/core/utils.py
@@ -183,14 +183,15 @@ ENTITY_ATTRIBUTE_ORDER = {
     "prefix": 0,
     "reference": 1,
     "name": 2,
-    "dataset": 3,
-    "organisation-entity": 4,
-    "start-date": 5,
-    "end-date": 6,
-    "entry-date": 7,
-    "typology": 8,
-    "geometry": 9,
-    "point": 10,
+    "quality": 3,
+    "dataset": 4,
+    "organisation-entity": 5,
+    "start-date": 6,
+    "end-date": 7,
+    "entry-date": 8,
+    "typology": 9,
+    "geometry": 10,
+    "point": 11,
 }
 
 
@@ -245,3 +246,30 @@ def log_slow_execution(threshold_seconds=1.0):
         return wrapper
 
     return decorator
+
+
+ENTITY_QUALITY_DESCRIPTION = {
+    "authoritative": "We have some data from the authoritative source",
+    "some": "We have some data from an alternative source",
+    "trustworthy": "We have authorititive data linked to material information",
+    "usable": "We have data from the authoritative source",
+}
+
+
+def map_entity_quality_to_description(e_dict_sorted: dict) -> dict:
+    """
+    Maps the `quality` entity field to the right description and
+    re-formats the entity quality field to be `[quality]: [description]`
+    without having to update the original quality value on the model.
+    """
+
+    quality = e_dict_sorted.get("quality")
+    if quality:
+        description = ENTITY_QUALITY_DESCRIPTION.get(quality, "")
+        if description:
+            e_dict_sorted["quality"] = f"{str(quality).capitalize()}: {description}"
+        else:
+            e_dict_sorted["quality"] = str(quality).capitalize()
+    else:
+        e_dict_sorted["quality"] = "We have no data"
+    return e_dict_sorted

--- a/application/core/utils.py
+++ b/application/core/utils.py
@@ -251,7 +251,7 @@ def log_slow_execution(threshold_seconds=1.0):
 ENTITY_QUALITY_DESCRIPTION = {
     "authoritative": "We have some data from the authoritative source",
     "some": "We have some data from an alternative source",
-    "trustworthy": "We have authorititive data linked to material information",
+    "trustworthy": "We have authoritative data linked to material information",
     "usable": "We have data from the authoritative source",
 }
 

--- a/application/db/models.py
+++ b/application/db/models.py
@@ -31,8 +31,11 @@ class EntityOrm(Base):
     typology = Column(Text, nullable=True)
     geometry = Column(Geometry(geometry_type="MULTIPOLYGON", srid=4326), nullable=True)
     point = Column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
+
+    # TODO: We need to create a model for `QualityOrm` and map it to `quality`
+    # so that we can access other quality attributes and remove the
+    # `map_entity_quality_to_description()` function
     quality = Column(Text, nullable=True)
-    # conside removing the geojson column as it's just empty right now
     geojson_col = Column(JSONB, name="geojson", nullable=True)
     _geometry_geojson = column_property(func.ST_AsGeoJSON(geometry))
     _point_geojson = column_property(func.ST_AsGeoJSON(point))

--- a/application/routers/entity.py
+++ b/application/routers/entity.py
@@ -39,6 +39,7 @@ from application.core.utils import (
     DigitalLandJSONResponse,
     to_snake,
     entity_attribute_sort_key,
+    map_entity_quality_to_description,
     make_links,
 )
 from application.exceptions import (
@@ -185,13 +186,16 @@ def handle_entity_response(
         key: e_dict[key] for key in sorted(e_dict.keys(), key=entity_attribute_sort_key)
     }
 
-    # CURIE field composed by the Prefix:Reference fields
+    # CURIE field composed by the prefix and reference fields
     prefix = e_dict.get("prefix")
     reference = e_dict.get("reference")
     curie = f"{prefix}:{reference}" if prefix and reference else None
 
     # Add CURIE field to dict and make it first
     e_dict_sorted = {"curie": curie, **e_dict_sorted}
+
+    # Map and re-format the quality value to include a description
+    e_dict_sorted = map_entity_quality_to_description(e_dict_sorted)
 
     # need to remove any dependency on facts this should be changed when fields added to postgis
     fields = None
@@ -252,6 +256,7 @@ def handle_entity_response(
         {
             "request": request,
             "row": e_dict_sorted,
+            "json_row": e_dict,
             "local_plan_geojson": local_plan_boundary_geojson,
             "linked_entities": linked_entities,
             "local_plans": local_plans,

--- a/application/templates/entity.html
+++ b/application/templates/entity.html
@@ -83,7 +83,7 @@
           </thead>
           <tbody class="govuk-table__body">
             {% for field in row.keys() %}
-              {% if field is not in ['entity','quality'] %}
+              {% if field is not in ['entity'] %}
               {%- if field not in ["geometry","point","organisation-entity","json"] or row[field] is not none  %}
               <tr class="govuk-table__row">
                 <th scope="row" class="app-table__header app-table__header--row">
@@ -103,7 +103,7 @@
                     {{ entityValue(field, row[field], fields, dataset_fields, organisation_entity, linked_entities, dataset) }}
                   {% endif %}
                 </td>
-                {% if field not in ['curie', 'dataset', 'organisation-entity', 'typology'] %}
+                {% if field not in ['curie', 'dataset', 'organisation-entity', 'typology', 'quality'] %}
                   <td class="govuk-table__cell govuk-!-font-size-14 govuk-!-text-align-right">
                     <a href="/fact?dataset={{ row['dataset'] }}&entity={{ row['entity'] }}&field={{ field }}" class="govuk-link">Facts</a>
                   </td>
@@ -126,7 +126,7 @@
       {% endcall %}
 
       {% set data_to_send = {
-        'row': row,
+        'row': json_row,
         'is_truncated': is_truncated
       } %}
       {% set jsonHTML %}

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -20,7 +20,7 @@ quality_test_data = [
     ),
     (
         {"quality": "trustworthy", "name": "Historic England"},
-        "Trustworthy: We have authorititive data linked to material information",
+        "Trustworthy: We have authoritative data linked to material information",
     ),
     (
         {"quality": "usable", "name": "Green space"},
@@ -126,20 +126,20 @@ class TestLogSlowExecution:
 
 class TestEntityQualityMapsToDescription:
     @pytest.mark.parametrize("entity_dict, expected", quality_test_data)
-    def test_entity_quality_maps_to_description_successfully(entity_dict, expected):
+    def test_entity_quality_maps_to_description_successfully(
+        self, entity_dict, expected
+    ):
         """Tests mapping the quality field value to the right description."""
         result = map_entity_quality_to_description(entity_dict)
         assert result["quality"] == expected
 
-
-    def test_entity_quality_maps_to_description_with_empty_quality():
+    def test_entity_quality_maps_to_description_with_empty_quality(self):
         """Tests function when the quality value is `None`."""
         entity_dict = {"quality": None, "name": "Test Entity"}
         result = map_entity_quality_to_description(entity_dict)
         assert result["quality"] == "We have no data"
 
-
-    def test_entity_quality_maps_to_description_with_unknown_quality():
+    def test_entity_quality_maps_to_description_with_unknown_quality(self):
         """Tests mapping fails, falls back gracefully."""
         entity_dict = {"quality": "special quality", "name": "Test Entity"}
         result = map_entity_quality_to_description(entity_dict)

--- a/tests/unit/core/test_utils.py
+++ b/tests/unit/core/test_utils.py
@@ -5,7 +5,28 @@ from application.core.utils import (
     entity_attribute_sort_key,
     make_pagination_query_str,
     log_slow_execution,
+    map_entity_quality_to_description,
 )
+
+
+quality_test_data = [
+    (
+        {"quality": "authoritative", "name": "Brownfield site"},
+        "Authoritative: We have some data from the authoritative source",
+    ),
+    (
+        {"quality": "some", "name": "Historical monument"},
+        "Some: We have some data from an alternative source",
+    ),
+    (
+        {"quality": "trustworthy", "name": "Historic England"},
+        "Trustworthy: We have authorititive data linked to material information",
+    ),
+    (
+        {"quality": "usable", "name": "Green space"},
+        "Usable: We have data from the authoritative source",
+    ),
+]
 
 
 def test_entity_attribute_sort_key_only_excepts_string():
@@ -101,3 +122,27 @@ class TestLogSlowExecution:
 
         mock_logger.info.assert_not_called()
         mock_logger.error.assert_called()
+
+
+class TestEntityQualityMapsToDescription:
+    @pytest.mark.parametrize("entity_dict, expected", quality_test_data)
+    def test_entity_quality_maps_to_description_successfully(entity_dict, expected):
+        """Tests mapping the quality field value to the right description."""
+        result = map_entity_quality_to_description(entity_dict)
+        assert result["quality"] == expected
+
+
+    def test_entity_quality_maps_to_description_with_empty_quality():
+        """Tests function when the quality value is `None`."""
+        entity_dict = {"quality": None, "name": "Test Entity"}
+        result = map_entity_quality_to_description(entity_dict)
+        assert result["quality"] == "We have no data"
+
+
+    def test_entity_quality_maps_to_description_with_unknown_quality():
+        """Tests mapping fails, falls back gracefully."""
+        entity_dict = {"quality": "special quality", "name": "Test Entity"}
+        result = map_entity_quality_to_description(entity_dict)
+
+        # Should title case the quality even if description not found
+        assert result["quality"] == "Special quality"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I'm splitting this work into 2 parts (entity - part 1 and map - part 2), in this part (part 1) adding a new UI field to the entity "Quality" which includes the quality name and the description. 

This map and re-format is only visible in the UI, the JSON data still has the original data/format. 

## Related Tickets & Documents
- [Ticket Link](https://github.com/digital-land/digital-land/issues/529)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings
* Go to https://www.development.planning.data.gov.uk/entity/1 and you should see the new field "Quality" with a value that includes the quality name and the description;
* Scroll down to the JSON section and you should see that the original json data hasn't changed;
* Go to https://www.development.planning.data.gov.uk/entity/1.json and you should also noticed that the original json data hasn't changed

<img width="940" height="784" alt="Screenshot from 2026-04-01 15-58-22" src="https://github.com/user-attachments/assets/689015b6-ffd8-46e7-b537-2eedf86c0a1f" />

## Added/updated tests?
- [X] Yes
- [ ] No, and this is why
- [ ] I need help with writing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public "quality" attribute to entity displays with human‑readable descriptions and a clear "We have no data" fallback.
  * Adjusted entity attribute ordering so "quality" appears in the expected position.

* **UI**
  * "Quality" now shows in the main Field/Value table (excluded from the "Facts" link).
  * JSON tab now shows the original unsorted entity data.

* **Tests**
  * Added tests for known, unknown and missing quality values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->