### PR TITLE
Fix entity enconding

### DIFF
--- a/application/core/filters.py
+++ b/application/core/filters.py
@@ -43,8 +43,7 @@ def geometry_reference_count(v):
 
 def make_param_str_filter(exclude_value, exclude_param, all):
     filtered_params = [
-        (param[0], param[1])
-        for param in all
+        (param[0], param[1]) for param in all
         if exclude_param != param[0] or exclude_value != param[1]
     ]
     return urlencode(filtered_params)

--- a/application/core/filters.py
+++ b/application/core/filters.py
@@ -42,13 +42,12 @@ def geometry_reference_count(v):
 
 
 def make_param_str_filter(exclude_value, exclude_param, all):
-    return "&".join(
-        [
-            "{}={}".format(param[0], param[1])
-            for param in all
-            if exclude_param != param[0] or exclude_value != param[1]
-        ]
-    )
+    filtered_params = [
+        (param[0], param[1])
+        for param in all
+        if exclude_param != param[0] or exclude_value != param[1]
+    ]
+    return urlencode(filtered_params)
 
 
 def _remove_value_from_list(list_input, values):

--- a/application/core/utils.py
+++ b/application/core/utils.py
@@ -46,7 +46,7 @@ def model_dumps(obj, *args, **kwargs):
     if isinstance(obj, date):
         return json.dumps(obj.__str__(), *args, **kwargs)
     else:
-        logging.warning(f"model_dumps: obj is of type {type(obj)}")
+        logging.debug(f"model_dumps: obj is of type {type(obj)}")
         return json.dumps(obj, *args, default=date_encoder, **kwargs)
 
 

--- a/application/routers/entity.py
+++ b/application/routers/entity.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlencode
 
 from dataclasses import asdict
 from typing import Optional, List, Set, Dict, Union
@@ -525,12 +526,7 @@ def search_entities(
                 if filter_name != "limit" and values is not None
             ],
             "url_query_params": {
-                "str": ("&").join(
-                    [
-                        "{}={}".format(param[0], param[1])
-                        for param in request.query_params._list
-                    ]
-                ),
+                "str": urlencode(request.query_params._list),
                 "list": request.query_params._list,
             },
             "next_url": next_url,

--- a/application/templates/entity.html
+++ b/application/templates/entity.html
@@ -105,7 +105,7 @@
                 </td>
                 {% if field not in ['curie', 'dataset', 'organisation-entity', 'typology'] %}
                   <td class="govuk-table__cell govuk-!-font-size-14 govuk-!-text-align-right">
-                    <a href="/fact?dataset={{ row['dataset'] }}&entity={{ row['entity'] }}&field={{ field }}" class="govuk-link">Facts</a>
+                    <a href="/fact?{{ {'dataset': row['dataset'], 'entity': row['entity'], 'field': field}|make_url_param_str }}" class="govuk-link">Facts</a>
                   </td>
                     {% else %}
                       <td class="govuk-table__cell govuk-!-font-size-14 govuk-!-text-align-right"><span class='govuk-visually-hidden'>no fact link</span></td>

--- a/application/templates/partials/fact-search-facets.html
+++ b/application/templates/partials/fact-search-facets.html
@@ -37,7 +37,7 @@
     {{ govukButton({
       "text": "Search"
     }) }}
-    <a href="{{ fact_search_form_url }}?dataset={{query_params['dataset']}}&entity={{query_params['entity']}}" class="govuk-link">Clear</a>
+    <a href="{{ fact_search_form_url }}?{{ {'dataset': query_params['dataset'], 'entity': query_params['entity']}|make_url_param_str }}" class="govuk-link">Clear</a>
   </div>
 
 </form>

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -177,18 +177,20 @@ def test_make_param_str_filter_no_exclusions():
 
 def test_make_param_str_filter_prevents_malformed_urls():
     """Tests that make_param_str_filter prevents creation of malformed URLs like &amp;entity=."""
-    params = [("dataset", "planning"), ("entity", "11500041"), ("field", "entry-date")]
+    params = [("dataset", "planning"), ("entity", "115;00041"), ("field", "entry-date")]
     exclude_value = "nonexistent"
     exclude_param = "nonexistent"
 
     result = make_param_str_filter(exclude_value, exclude_param, params)
 
+    assert "115%3B00041" in result  # Semicolon is enconded
+    assert ";" not in result  # Raw semicoln does not leak through
     assert "amp;" not in result  # No amp; prefixes
     assert "&amp;" not in result  # No HTML-encoded ampersands
     assert (
         "%3B" not in result or ";" not in result
     )  # Either encoded or unencoded, not mixed
 
-    expected_parts = ["dataset=planning", "entity=11500041", "field=entry-date"]
+    expected_parts = ["dataset=planning", "entity=115%3B00041", "field=entry-date"]
     for part in expected_parts:
         assert part in result

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -3,6 +3,7 @@ from application.core.filters import (
     remove_param_from_param_dict,
     remove_values_from_param_dict,
     make_url_param_str,
+    make_param_str_filter,
     cacheBust,
     append_uri_param,
     hash_file,
@@ -134,3 +135,60 @@ def test_make_url_param_str_all_arguements():
     expected = "field=typology&test=test_value_1&test=test_value_2&test=test_value_3"
     result = make_url_param_str(input_param_dict, exclude_values, exclude_params)
     assert result == expected
+
+
+def test_make_param_str_filter_url_encoding():
+    """Tests that special characters are properly URL encoded."""
+    params = [
+        ("dataset", "planning-application"),
+        ("entity", "123;456"),
+        ("field", "test&value"),
+    ]
+    exclude_value = "nonexistent"
+    exclude_param = "nonexistent"
+
+    result = make_param_str_filter(exclude_value, exclude_param, params)
+
+    assert "dataset=planning-application" in result
+    assert "entity=123%3B456" in result  # ; becomes %3B
+    assert "field=test%26value" in result  # & becomes %26
+
+
+def test_make_param_str_filter_with_empty_params():
+    """Tests passing empty parameter list to `make_param_str_filter` returns empty string."""
+    params = []
+    exclude_value = "test"
+    exclude_param = "test"
+
+    result = make_param_str_filter(exclude_value, exclude_param, params)
+    assert result == ""
+
+
+def test_make_param_str_filter_no_exclusions():
+    """Tests no parameters match the exclusion criteria."""
+    params = [("dataset", "test"), ("entity", "123")]
+    exclude_value = "nonexistent"
+    exclude_param = "nonexistent"
+
+    result = make_param_str_filter(exclude_value, exclude_param, params)
+    assert "dataset=test" in result
+    assert "entity=123" in result
+
+
+def test_make_param_str_filter_prevents_malformed_urls():
+    """Tests that make_param_str_filter prevents creation of malformed URLs like &amp;entity=."""
+    params = [("dataset", "planning"), ("entity", "11500041"), ("field", "entry-date")]
+    exclude_value = "nonexistent"
+    exclude_param = "nonexistent"
+
+    result = make_param_str_filter(exclude_value, exclude_param, params)
+
+    assert "amp;" not in result  # No amp; prefixes
+    assert "&amp;" not in result  # No HTML-encoded ampersands
+    assert (
+        "%3B" not in result or ";" not in result
+    )  # Either encoded or unencoded, not mixed
+
+    expected_parts = ["dataset=planning", "entity=11500041", "field=entry-date"]
+    for part in expected_parts:
+        assert part in result


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes double encoding such as `/fact.json?amp%3Bentity=11500041&dataset=permitted-development-right&amp%3Bfield=entry-date` which are returning 500 errors on Sentry.

* [Log trace](https://communitiesuk.sentry.io/explore/logs/trace/9fab4cd5e6bb4b1e828bd6d237d474c8/?environment=development&logsSortBys=-timestamp&project=4510975780585552&source=logs&timestamp=1777278740)
* [Error detail](https://communitiesuk.sentry.io/issues/100927672/?environment=development&project=4510975780585552&query=issue.category%3A%5Berror%2Coutage%5D&referrer=issue-stream)

In the code the queryparams are being received as:
`QueryParams('amp%3Bentity=11500041&dataset=permitted-development-right&amp%3Bfield=entry-date')`
But because of double encoding its not catching entity or field:
`amp%3Bentity=11500041`

## Related Tickets & Documents
- [Related Issue #](https://github.com/digital-land/config/issues/2483)

## QA Instructions, Screenshots, Recordings
Keep an eye on Sentry to understand if this fix has worked

## Added/updated tests?
- [x] Yes
- [ ] No, and this is why
- [ ] I need help with writing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query-string generation to avoid malformed ampersand artifacts and ensure consistent parameter encoding.

* **Refactor**
  * Switched parameter string construction to standard URL-encoding for more reliable, predictable formatting across the app and templates.

* **Chores**
  * Lowered an internal log message from warning to debug to reduce noise.

* **Tests**
  * Added unit tests covering encoding, exclusions and empty-parameter behaviours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->