### PR TITLE
Update queryfilters validation

### DIFF
--- a/application/search/filters.py
+++ b/application/search/filters.py
@@ -4,9 +4,7 @@ from typing import Optional, List
 from fastapi import Query, Header
 from pydantic import validator
 from pydantic.dataclasses import dataclass
-from sqlalchemy import text
 
-from application.db.session import get_context_session
 from application.exceptions import (
     InvalidGeometry,
 )
@@ -23,6 +21,8 @@ from application.search.validators import (
     validate_year_integer,
     validate_curies,
 )
+from shapely import wkt
+from shapely.geometry.base import BaseGeometry
 
 
 @dataclass
@@ -278,44 +278,24 @@ class QueryFilters:
         validate_curies
     )
 
-    # TODO Replace with a solution that doesn't need a database?
     @validator("geometry", pre=True)
     def validate_geometry(cls, geometry_values_list: Optional[list]):
         if not geometry_values_list:
             return geometry_values_list
-        with get_context_session() as session:
-            for geometry in geometry_values_list:
-                try:
-                    stmt = text("SELECT ST_GeomFromText(:geometry, 4326);")
-                    stmt = stmt.bindparams(geometry=geometry)
-                    result = session.execute(stmt).fetchone()
-
-                    if result[0] is None:
-                        raise InvalidGeometry(f"Invalid geometry {geometry}")
-
-                    # Validate Geometry
-                    validate_stmt = text(
-                        "SELECT ST_IsValid(ST_GeomFromText(:geometry, 4326));"
-                    )
-                    validate_stmt = validate_stmt.bindparams(geometry=geometry)
-                    is_valid_result = session.execute(validate_stmt).fetchone()
-
-                    if not is_valid_result[0]:
-                        raise InvalidGeometry(f"Invalid geometry {geometry}")
-
-                except Exception as e:
-                    # Check if the geometry passed has GeoJSON format instead
-                    geometry_str = str(geometry).strip()
-                    if geometry_str.startswith('{"type"') or geometry_str.startswith(
-                        '"{"type"'
-                    ):
-                        raise InvalidGeometry(
-                            f"Invalid geometry format. Expected WKT format "
-                            f"(e.g., 'POLYGON((...))'), but received GeoJSON format. "
-                            f"Please convert your GeoJSON to WKT format."
-                        )
-                    else:
-                        raise InvalidGeometry(f"Invalid geometry {geometry}")
+        for geometry in geometry_values_list:
+            try:
+                geom: BaseGeometry = wkt.loads(geometry)
+                if not geom.is_valid:
+                    raise InvalidGeometry(f"Invalid geometry {geometry}")
+            except InvalidGeometry:
+                raise
+            except Exception as err:
+                geometry_str = str(geometry).strip()
+                if '{"type"' in geometry_str:
+                    raise InvalidGeometry(
+                        "Expected WKT format, received GeoJSON instead"
+                    ) from err
+                raise InvalidGeometry(f"Invalid geometry {geometry}") from err
         return geometry_values_list
 
 

--- a/application/search/filters.py
+++ b/application/search/filters.py
@@ -280,18 +280,43 @@ class QueryFilters:
 
     # TODO Replace with a solution that doesn't need a database?
     @validator("geometry", pre=True)
-    def validate_geometry(cls, v: Optional[list]):
-        if not v:
-            return v
+    def validate_geometry(cls, geometry_values_list: Optional[list]):
+        if not geometry_values_list:
+            return geometry_values_list
         with get_context_session() as session:
-            for geometry in v:
+            for geometry in geometry_values_list:
                 try:
-                    stmt = text("SELECT ST_IsValid(:geometry);")
+                    stmt = text("SELECT ST_GeomFromText(:geometry, 4326);")
                     stmt = stmt.bindparams(geometry=geometry)
-                    session.execute(stmt)
-                except Exception:
-                    raise InvalidGeometry(f"Invalid geometry {geometry}")
-        return v
+                    result = session.execute(stmt).fetchone()
+
+                    if result[0] is None:
+                        raise InvalidGeometry(f"Invalid geometry {geometry}")
+
+                    # Validate Geometry
+                    validate_stmt = text(
+                        "SELECT ST_IsValid(ST_GeomFromText(:geometry, 4326));"
+                    )
+                    validate_stmt = validate_stmt.bindparams(geometry=geometry)
+                    is_valid_result = session.execute(validate_stmt).fetchone()
+
+                    if not is_valid_result[0]:
+                        raise InvalidGeometry(f"Invalid geometry {geometry}")
+
+                except Exception as e:
+                    # Check if the geometry passed has GeoJSON format instead
+                    geometry_str = str(geometry).strip()
+                    if geometry_str.startswith('{"type"') or geometry_str.startswith(
+                        '"{"type"'
+                    ):
+                        raise InvalidGeometry(
+                            f"Invalid geometry format. Expected WKT format "
+                            f"(e.g., 'POLYGON((...))'), but received GeoJSON format. "
+                            f"Please convert your GeoJSON to WKT format."
+                        )
+                    else:
+                        raise InvalidGeometry(f"Invalid geometry {geometry}")
+        return geometry_values_list
 
 
 @dataclass

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -220,6 +220,14 @@ wkt_params = [
     ("\t", 422),
 ]
 
+geojson_params = [
+    (
+        '{"type":"Polygon","coordinates":[[[-0.1459907,51.4805203],[-0.1429907,51.4805203],[-0.1429907,51.4835203],[-0.1459907,51.4835203],[-0.1459907,51.4805203]]]}',
+        422,
+    ),
+    ('"{"type":"Point","coordinates":[-0.33753991127014155,53.74458682618967]}"', 422),
+]
+
 
 @pytest.mark.parametrize("point, expected_status_code", wkt_params)
 def test_api_handles_invalid_wkt(point, expected_status_code, client, test_data):
@@ -229,6 +237,21 @@ def test_api_handles_invalid_wkt(point, expected_status_code, client, test_data)
     data = response.json()
     if data.get("detail") is not None:
         assert f"Invalid geometry {point}" == data["detail"][0]["msg"]
+
+
+@pytest.mark.parametrize("geojson_geometry, expected_status_code", geojson_params)
+def test_api_rejects_geojson_format_with_helpful_error(
+    geojson_geometry, expected_status_code, client, test_data
+):
+    params = {"geometry_relation": "intersects", "geometry": geojson_geometry}
+    response = client.get("/entity.geojson", params=params)
+    assert response.status_code == expected_status_code
+    data = response.json()
+    if data.get("detail") is not None:
+        error_msg = data["detail"][0]["msg"]
+        assert "Expected WKT format" in error_msg
+        assert "GeoJSON format" in error_msg
+        assert "Please convert" in error_msg
 
 
 def test_search_by_entity_and_geometry_entity_require_numeric_id(client, test_data):

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -230,7 +230,7 @@ geojson_params = [
     ),
     (
         '"{"type":"Point","coordinates":[-0.33753991127014155,53.74458682618967]}"',
-        'Invalid geometry "{"type":"Point","coordinates":[-0.33753991127014155,53.74458682618967]}"',
+        "Expected WKT format, received GeoJSON instead",
         422,
     ),
 ]

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -222,10 +222,17 @@ wkt_params = [
 
 geojson_params = [
     (
-        '{"type":"Polygon","coordinates":[[[-0.1459907,51.4805203],[-0.1429907,51.4805203],[-0.1429907,51.4835203],[-0.1459907,51.4835203],[-0.1459907,51.4805203]]]}',
+        '{"type":"Polygon","coordinates":'
+        "[[[-0.1459907,51.4805203],[-0.1429907,51.4805203],"
+        "[-0.1429907,51.4835203],[-0.1459907,51.4835203],[-0.1459907,51.4805203]]]}",
+        "Expected WKT format, received GeoJSON instead",
         422,
     ),
-    ('"{"type":"Point","coordinates":[-0.33753991127014155,53.74458682618967]}"', 422),
+    (
+        '"{"type":"Point","coordinates":[-0.33753991127014155,53.74458682618967]}"',
+        'Invalid geometry "{"type":"Point","coordinates":[-0.33753991127014155,53.74458682618967]}"',
+        422,
+    ),
 ]
 
 
@@ -239,19 +246,19 @@ def test_api_handles_invalid_wkt(point, expected_status_code, client, test_data)
         assert f"Invalid geometry {point}" == data["detail"][0]["msg"]
 
 
-@pytest.mark.parametrize("geojson_geometry, expected_status_code", geojson_params)
+@pytest.mark.parametrize(
+    "geojson_geometry, expected_message, expected_status_code", geojson_params
+)
 def test_api_rejects_geojson_format_with_helpful_error(
-    geojson_geometry, expected_status_code, client, test_data
+    geojson_geometry, expected_message, expected_status_code, client, test_data
 ):
     params = {"geometry_relation": "intersects", "geometry": geojson_geometry}
     response = client.get("/entity.geojson", params=params)
     assert response.status_code == expected_status_code
+
     data = response.json()
-    if data.get("detail") is not None:
-        error_msg = data["detail"][0]["msg"]
-        assert "Expected WKT format" in error_msg
-        assert "GeoJSON format" in error_msg
-        assert "Please convert" in error_msg
+    error_msg = data["detail"][0]["msg"]
+    assert error_msg == expected_message
 
 
 def test_search_by_entity_and_geometry_entity_require_numeric_id(client, test_data):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Essentially we started getting a lot of logs where the geometry passed in the url did not have the expected WKT format, instead it is being passed as GeoJSON format.

As expected the filters raise this error but without much context as to why it was happening which led to some panic in the team.

You can see the [error occurring in production](https://communitiesuk.sentry.io/issues/116631808/?environment=production&project=4510975780585552&query=is%3Aunresolved%20issue.category%3A%5Berror%2Coutage%5D&referrer=issue-stream)

## Related Tickets & Documents
There is no ticket, I saw this error happening, reached out to Owen and decided to make this improvement.

- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings
Once on Dev environment please visit https://www.development.planning.data.gov.uk/entity.json?limit=50&geometry_relation=intersects&dataset=planning-application&geometry=%7B%22type%22%3A%22Polygon%22%2C%22coordinates%22%3A%5B%5B%5B-0.1459907%2C51.4805203%5D%2C%5B-0.1429907%2C51.4805203%5D%2C%5B-0.1429907%2C51.4835203%5D%2C%5B-0.1459907%2C51.4835203%5D%2C%5B-0.1459907%2C51.4805203%5D%5D%5D%7D and you should see a JSON message explaining the geometry wrong format rather than just a 500 error:

<img width="1913" height="909" alt="Screenshot from 2026-05-05 11-48-14" src="https://github.com/user-attachments/assets/df906e05-b5db-4ecd-a6d5-68da42d4d8b8" />

After:

<img width="1424" height="697" alt="Screenshot from 2026-05-05 13-56-57" src="https://github.com/user-attachments/assets/2828d6a5-5b65-4cb0-aa16-c154f9705ccf" />


## Added/updated tests?
- [X] Yes
- [ ] No, and this is why
- [ ] I need help with writing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geometry parameter validation and clearer error messages: GeoJSON inputs are now detected and the response instructs users to convert GeoJSON to WKT, with more precise rejection of invalid geometries.
* **Tests**
  * Added integration tests to ensure GeoJSON-format geometries are rejected with the helpful conversion guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->