### PR TITLE
465 Add Inset Text to entities that have end dates in the past

### DIFF
--- a/application/core/filters.py
+++ b/application/core/filters.py
@@ -43,7 +43,8 @@ def geometry_reference_count(v):
 
 def make_param_str_filter(exclude_value, exclude_param, all):
     filtered_params = [
-        (param[0], param[1]) for param in all
+        (param[0], param[1])
+        for param in all
         if exclude_param != param[0] or exclude_value != param[1]
     ]
     return urlencode(filtered_params)
@@ -356,12 +357,14 @@ def format_date(date_str):
 
 def is_past_date(date_obj):
     """
-    Checks if the date obj passed as an argument is in the past.
+    Checks if the date passed as an argument is in the past.
     """
     if not date_obj:
         return False
 
     try:
+        if isinstance(date_obj, str):
+            date_obj = datetime.fromisoformat(date_obj).date()
         return date_obj < datetime.now().date()
     except (ValueError, TypeError):
         return False

--- a/application/core/filters.py
+++ b/application/core/filters.py
@@ -352,3 +352,16 @@ def format_date(date_str):
     # Format the date with the ordinal suffix
     formatted_date = f"{day}{suffix} {date_obj.strftime('%B %Y')}"
     return formatted_date
+
+
+def is_past_date(date_obj):
+    """
+    Checks if the date obj passed as an argument is in the past.
+    """
+    if not date_obj:
+        return False
+
+    try:
+        return date_obj < datetime.now().date()
+    except (ValueError, TypeError):
+        return False

--- a/application/core/templates.py
+++ b/application/core/templates.py
@@ -25,6 +25,7 @@ from application.core.filters import (
     get_entity_paint_options,
     get_os_oauth2_token,
     format_date,
+    is_past_date,
 )
 
 from application.core.utils import model_dumps
@@ -84,6 +85,7 @@ templates.env.filters["slugify"] = to_slug
 templates.env.filters["extract_component_key"] = extract_component_key
 templates.env.filters["get_entity_geometry"] = get_entity_geometry
 templates.env.filters["format_date"] = format_date
+templates.env.filters["is_past_date"] = is_past_date
 
 # TODO This is a filter which should only need one variable, apparently ther
 # eis something called context processors that we should use

--- a/application/templates/entity.html
+++ b/application/templates/entity.html
@@ -65,8 +65,8 @@
 
     {% if row['end-date'] and row['end-date'] | is_past_date %}
       <div class="govuk-inset-text">
-        <p class="govuk-body govuk-!-font-weight-bold">This dataset is out of date</p>
-        <p>You should only use this dataset if you need to check data from the past.</p>
+        <p class="govuk-body govuk-!-font-weight-bold">This entity is out of date</p>
+        <p>You should only use this entity if you need to check data from the past.</p>
       </div>
     {% endif %}
 

--- a/application/templates/entity.html
+++ b/application/templates/entity.html
@@ -15,10 +15,6 @@
   {% endif %}
 {% endif %}
 
-
-
-
-
 {% if row['name'] %}
   {%- set row_name = row['name'] %}
 {%- elif row['reference'] %}
@@ -66,6 +62,22 @@
 
 {%- block content %}
   <div class="govuk-grid-row">
+
+    {% if row['end-date'] and row['end-date'] | is_past_date %}
+      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <p class="govuk-notification-banner__heading">
+            No longer in effect.
+          </p>
+        </div>
+      </div>
+    {% endif %}
+
     <div class="govuk-grid-column-full">
       <span class="govuk-caption-xl">{{ dataset.name }}</span>
       <h1 class="govuk-heading-xl">{{ row_name }}</h1>

--- a/application/templates/entity.html
+++ b/application/templates/entity.html
@@ -64,17 +64,9 @@
   <div class="govuk-grid-row">
 
     {% if row['end-date'] and row['end-date'] | is_past_date %}
-      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-        <div class="govuk-notification-banner__header">
-          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-            Important
-          </h2>
-        </div>
-        <div class="govuk-notification-banner__content">
-          <p class="govuk-notification-banner__heading">
-            No longer in effect.
-          </p>
-        </div>
+      <div class="govuk-inset-text">
+        <p class="govuk-body govuk-!-font-weight-bold">This dataset is out of date</p>
+        <p>You should only use this dataset if you need to check data from the past.</p>
       </div>
     {% endif %}
 

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
 from application.core.filters import (
     _remove_value_from_list,
     remove_param_from_param_dict,
@@ -7,6 +10,7 @@ from application.core.filters import (
     cacheBust,
     append_uri_param,
     hash_file,
+    is_past_date,
 )
 
 
@@ -194,3 +198,24 @@ def test_make_param_str_filter_prevents_malformed_urls():
     expected_parts = ["dataset=planning", "entity=115%3B00041", "field=entry-date"]
     for part in expected_parts:
         assert part in result
+def test_is_past_date():
+    """
+    Tests `is_past_date()` only returns True when a date object passed
+    as an argument is in the past.
+    """
+    today = datetime.today()
+
+    # Assert with a end-date in the future
+    end_date_two_years_in_future = (today + relativedelta(years=2)).date()
+    result = is_past_date(end_date_two_years_in_future)
+    assert result is False
+
+    # Assert with today's date
+    end_date_is_today = today.date()
+    result = is_past_date(end_date_is_today)
+    assert result is False
+
+    # Assert with a end-date in the past
+    end_date_three_years_in_past = (today - relativedelta(years=3)).date()
+    result = is_past_date(end_date_three_years_in_past)
+    assert result is True


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds an "inset text" component from GDS on entities that have the "End date" in the past (a date before today/the current day)

## Related Tickets & Documents
- [Ticket Link](https://github.com/digital-land/digital-land/issues/465)
- Related Issue #
- [Closes #](https://github.com/digital-land/digital-land/issues/465)

## QA Instructions, Screenshots, Recordings
End date in the past
<img width="1498" height="1032" alt="Screenshot from 2026-05-06 14-50-58" src="https://github.com/user-attachments/assets/6b47bb0f-586a-4765-9601-570502c9dcca" />

End date is in the future
<img width="1498" height="1032" alt="Screenshot from 2026-05-06 14-53-20" src="https://github.com/user-attachments/assets/081271ac-3bae-4009-8007-71281e51ce92" />

No end date
<img width="1498" height="1032" alt="Screenshot from 2026-05-06 14-53-46" src="https://github.com/user-attachments/assets/b82f13bb-4006-4460-8075-ba1c1f3ffe1a" />


## Added/updated tests?
- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New alert displays when an entity has reached or passed its end date, informing users the entity is out of date
  * GeoJSON and geometry data now load on-demand with a new tab interface; large files gracefully fall back to downloadable formats with loading indicators and error handling

* **Tests**
  * Added comprehensive tests for date validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->