### PR TITLE
502 - Update statistical geography url link

### DIFF
--- a/application/templates/components/entity-value/macro.jinja
+++ b/application/templates/components/entity-value/macro.jinja
@@ -75,7 +75,7 @@
         {%- elif field in ["parliament-thesaurus"] %}
             <a class ="govuk-link" href="{{ 'https://lda.data.parliament.uk/terms/' + value }}">{{ value }}</a>
         {%- elif field in ["statistical-geography"] %}
-            <a class ="govuk-link" href="{{ 'https://statistics.data.gov.uk/id/statistical-geography/' + value }}">{{ value }}</a>
+            <a class ="govuk-link" href="{{ 'https://www.ons.gov.uk/explore-local-statistics/areas/' + value }}">{{ value }}</a>
         {%- elif field in ["ramsar-site"] %}
             <a class ="govuk-link" href="{{ 'https://rsis.ramsar.org/ris/' + value }}">{{ value }}</a>
         {%- elif field in ["typology"] %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Update redirect url for the entity statistical geography link. 

The current url is pointing to the old service which is now decommissioned.


## Related Tickets & Documents
- [Ticket Link](https://github.com/digital-land/digital-land.info/issues/502)
- Related Issue #
- [Closes #](https://github.com/digital-land/digital-land.info/issues/502)

## QA Instructions, Screenshots, Recordings

- Go to https://www.development.planning.data.gov.uk/entity/172
- Scroll down to "Statistical geography" and click on the link value, you should be redirected to [the correct service](https://www.ons.gov.uk/explore-local-statistics/areas/E12000001-north-east)

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: Simple external url update
- [ ] I need help with writing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated external links for statistical geography data to direct to the ONS explore local statistics service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->