### PR TITLE
550 Enable parquet file downloads

### DIFF
--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -234,6 +234,9 @@
             <li>
               <a class="govuk-link" href="{{ data_file_url }}/dataset/{{ dataset['dataset'] }}.geojson">GeoJSON</a>
             </li>
+            <li>
+              <a class="govuk-link" href="{{ data_file_url }}/dataset/{{ dataset['dataset'] }}.parquet">Parquet</a>
+            </li>
             {% endif %}
           </ul>
         </nav>

--- a/application/templates/pages/about/roadmap.md
+++ b/application/templates/pages/about/roadmap.md
@@ -36,10 +36,10 @@ We are also developing Extract in partnership with the [Incubator for AI](https:
 
 ### Now
 
-- We are making it faster and more reliable to build and rebuild planning data. Our platform can now be refreshed in hours rather than days, giving users quicker access to up-to-date, authoritative information. This work has also allowed us to scale our infrastructure, increasing the number of [title boundaries](https://www.planning.data.gov.uk/dataset/title-boundary) available on the platform. 
+- We are making it faster and more reliable to build and rebuild planning data. Our platform can now be refreshed in hours rather than days, giving users quicker access to up-to-date, authoritative information. This work has also allowed us to scale our infrastructure, increasing the number of [title boundaries](https://www.planning.data.gov.uk/dataset/title-boundary) available on the platform.
 - We are improving [our service for data providers](https://provide.planning.data.gov.uk). The service is now more responsive, with faster loading times, clearer guidance and new features such as showing non-authoritative data from alternative public sources. All of these help LPAs understand, improve and maintain the quality of the data they’ve provided.
 - We are bringing data quality checks directly into the service. This allows LPAs to validate data earlier, submit smaller datasets more easily, and publish high-quality data sooner - increasing the amount of trusted, authoritative data available on the platform.
-- We are testing Extract with real planning documents and staff working at local planning authorities to understand where it helps most and where it needs improvement (also known as the [alpha phase](https://www.gov.uk/service-manual/agile-delivery/how-the-alpha-phase-works)). 
+- We are testing Extract with real planning documents and staff working at local planning authorities to understand where it helps most and where it needs improvement (also known as the [alpha phase](https://www.gov.uk/service-manual/agile-delivery/how-the-alpha-phase-works)).
 - We are improving the experience so it’s clearer, easier and faster to turn documents into trustworthy data, and ensuring that it outputs high-quality data reliably.
 
 ### Next
@@ -66,11 +66,10 @@ We are making planning and housing data easier to access, understand and reuse -
 
 - We are publishing live platform performance metrics, so users can clearly understand reliability and availability.
 - We are publishing dataset quality and coverage information, so users can understand what data we currently have.
-- We are improving map search by Local Planning Authority and Town, so users can find relevant data more easily.
+- We are improving map search by Town, so users can find relevant data more easily.
 
 ### Next
 
-- We plan to provide datasets in formats such as Parquet to support large‑scale analysis and reuse.
 - We intend to package datasets around common user needs, with clearer context and guidance, to make them easier to use and consume.
 
 ### Later

--- a/assets/javascripts/analytics/file-download.js
+++ b/assets/javascripts/analytics/file-download.js
@@ -37,7 +37,7 @@ document.addEventListener('click', function (event) {
   const link = event.target.closest('a');
   if (!link || !link.href) return;
 
-  const fileExtensions = ['.geojson', '.json', '.xml', '.gml', '.kml', '.gpkg', '.shp'];
+  const fileExtensions = ['.geojson', '.json', '.xml', '.gml', '.kml', '.gpkg', '.shp', '.parquet'];
 
   let url;
   try {

--- a/tests/acceptance/test_analytics_file_downloads.py
+++ b/tests/acceptance/test_analytics_file_downloads.py
@@ -112,6 +112,7 @@ def test_file_download_tracking_respects_cookie_consent(
             "kml",
             "gpkg",
             "shp",
+            "parquet",
         ]
 
 
@@ -188,7 +189,7 @@ def test_file_download_tracking_ignores_non_download_links(server_url, page: Pag
 
 
 @pytest.mark.parametrize(
-    "extension", ["geojson", "json", "xml", "gml", "kml", "gpkg", "shp"]
+    "extension", ["geojson", "json", "xml", "gml", "kml", "gpkg", "shp", "parquet"]
 )
 def test_file_download_tracking_captures_different_extensions(
     server_url, page: Page, extension

--- a/tests/acceptance/test_dataset.py
+++ b/tests/acceptance/test_dataset.py
@@ -44,6 +44,14 @@ def test_download_data_for_dataset(server_url, page, app_test_data):
     assert "brownfield-site" in geojson_href
     assert ".geojson" in geojson_href
 
+    # Check that the "Parquet" download link is correct.
+    parquet_href = page.get_by_role(
+        "link", name="Parquet", exact=True
+    ).first.get_attribute("href")
+
+    assert "brownfield-site" in parquet_href
+    assert ".parquet" in parquet_href
+
 
 @pytest.mark.skip(reason="Temporarily disabled. Playwright Issues")
 def test_navigate_to_a_dataset_specification(server_url, page, app_test_data):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add ability to download all dataset data (dataset entities) in a parquet file. Extends google analytics to also track parquet file downloads.

## Related Tickets & Documents
- [Ticket Link](https://github.com/digital-land/digital-land/issues/550)
- Related Issue #
- [Closes #](https://github.com/digital-land/digital-land/issues/550)

## QA Instructions, Screenshots, Recordings
Once on Development environment:
* go to the Datasets page
* click on a dataset and you should see the parquet file download link
* click on the parquet file download link and you should be able to download the file

## Added/updated tests?
- [X] Yes (updated existing ones)
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
