### PR TITLE
616 local plans packages v2

### DIFF
--- a/application/core/constants.py
+++ b/application/core/constants.py
@@ -1,0 +1,2 @@
+# External gov.uk links
+GOV_UK_LOCAL_PLANS_URL = "https://www.gov.uk/housing-local-and-community/local-plans"

--- a/application/core/templates.py
+++ b/application/core/templates.py
@@ -4,6 +4,7 @@ from fastapi.templating import Jinja2Templates
 
 import random
 
+from application.core.constants import GOV_UK_LOCAL_PLANS_URL
 from application.core.filters import (
     generate_query_param_str,
     geometry_reference_count,
@@ -62,6 +63,8 @@ templates.env.globals["templateVar"] = {"email": "digitalland@communities.gov.uk
 templates.env.globals["serviceStatus"] = False
 templates.env.globals["gaMeasurementId"] = settings.GA_MEASUREMENT_ID
 templates.env.globals["smartLookId"] = settings.SMARTLOOK_ID
+templates.env.globals["govUkLocalPlansUrl"] = GOV_UK_LOCAL_PLANS_URL
+
 # Set a global `govukRebrand` variable to allow the
 # class `govuk-template--rebranded` being added to the base template
 # ensuring Govuk Rebrand is applied

--- a/application/templates/local_plans.html
+++ b/application/templates/local_plans.html
@@ -47,6 +47,17 @@
             </li>
           </ul>
         </nav>
+        <hr class="govuk-section-break govuk-section-break--m">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-0" id="useful-links">
+          Useful links
+        </h2>
+        <nav role="navigation" aria-labelledby="view-the-data">
+          <ul class="govuk-list govuk-!-font-size-16">
+            <li>
+              <a class="govuk-link" href="{{ govUkLocalPlansUrl }}">Creating or updating a local plan</a>
+            </li>
+          </ul>
+        </nav>
       </aside>
     </div>
   </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Final UI update for local-plans page, added a new "Useful links" section as per the [figma](https://www.figma.com/design/loyGKlOooxUJ44qJPgrkaa/Data-collections---search?node-id=145-2567&p=f&t=u5pWaoI0efnFgajd-0) file (see screenshots below)

In the process, finally decided to add a new constants module to the application. There are too many URLs flying around in multiple templates which if one of them changes we need to do a fair bit of search and update which doesn't seem to be the right approach. 

With a constants file, we only need to update it once and can re-use throughout the application which seems a bit cleaner. 

## Related Tickets & Documents
- [Ticket Link](https://github.com/digital-land/digital-land/issues/616)
- Related Issue #
- [Closes #](https://github.com/digital-land/digital-land/issues/616)

## QA Instructions, Screenshots, Recordings
Currently deploying to development. Once on development go to:
* https://www.development.planning.data.gov.uk/local-plans/ and you should see the changes applied as specified on Figma

<img width="1455" height="1033" alt="Screenshot from 2026-06-03 12-45-52" src="https://github.com/user-attachments/assets/77d03476-3383-49fe-9deb-a86267067beb" />


## Added/updated tests?
- [ ] Yes
- [X] No, and this is why: Template changes only
- [ ] I need help with writing tests