### PR TITLE
fix: make alembic task model same in staging as in dev and prod

### DIFF
--- a/migrations/versions/08139a9624a2_reconcile_task_table_details_jsonb_cols_.py
+++ b/migrations/versions/08139a9624a2_reconcile_task_table_details_jsonb_cols_.py
@@ -1,0 +1,57 @@
+"""reconcile task table details jsonb cols and indexes
+
+The previous migration (a41b142924f7) was edited in place after it had already
+been applied to staging — its `details` column was changed from Text to JSONB
+(plus NOT NULL constraints and indexes) under the same revision id. Because
+Alembic only tracks the revision id, not the file contents, staging never re-ran
+it and kept the old Text schema, which made /task.json fail with "details value
+is not a valid dict". This migration is a fresh revision that re-applies those
+changes so every environment converges on the correct schema.
+
+
+Revision ID: 08139a9624a2
+Revises: a41b142924f7
+Create Date: 2026-06-22 12:53:01.587036
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision = '08139a9624a2'
+down_revision = 'a41b142924f7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # text -> jsonb. USING is required to cast; NULLIF guards empty-string rows
+    # (''::jsonb errors) by turning them into NULL first.
+    op.alter_column(
+        "task", "details",
+        type_=JSONB(), existing_type=sa.Text(),
+        postgresql_using="NULLIF(btrim(details::text), '')::jsonb",
+        existing_nullable=True,
+    )
+    for col in ("dataset", "severity", "responsibility", "task_source"):
+        op.alter_column("task", col, existing_type=sa.Text(), nullable=False)
+    # idempotent - dev already has these from the edited migration
+    for idx, cols in [("idx_task_dataset", "dataset"),
+                      ("idx_task_organisation", "organisation"),
+                      ("idx_task_severity", "severity"),
+                      ("idx_task_responsibility", "responsibility")]:
+        op.execute(f"CREATE INDEX IF NOT EXISTS {idx} ON task ({cols})")
+
+
+def downgrade():
+    op.alter_column(
+        "task", "details",
+        type_=sa.Text(), existing_type=JSONB(),
+        postgresql_using="details::text",
+        existing_nullable=True,
+    )
+    for col in ("dataset", "severity", "responsibility", "task_source"):
+        op.alter_column("task", col, existing_type=sa.Text(), nullable=True)
+


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the previous migration (a41b142924f7) I edited it in place after it had already
been applied to staging — its `details` column was changed from Text to JSONB
(plus NOT NULL constraints and indexes) under the same revision id. 

Because Alembic only tracks the revision id, not the file contents, staging never re-ran
it and kept the old Text schema, which made /task.json fail with "details value
is not a valid dict". 

This migration is a fresh revision that re-applies those
changes so every environment converges on the correct schema.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

I have done some checks locally that the formatting is all correct but now need to run in staging and then DEV to be sure its ready to merge.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimised task table schema by improving data structure for task details and enforcing stricter validation constraints on key fields.
  * Added database indexes to improve query performance and ensure consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->