### PR TITLE
Fix missing query parameter descriptions on API docs page

### DIFF
--- a/application/search/filters.py
+++ b/application/search/filters.py
@@ -38,10 +38,12 @@ class DatasetQueryFilters:
         Optional[List[str]],
         Query(description="Fields to exclude from the dataset JSON response"),
     ] = None
-    include_typologies: bool = Query(
-        True,
-        description="Include typologies in dataset JSON response; set to false to remove",
-    )
+    include_typologies: Annotated[
+        bool,
+        Query(
+            description="Include typologies in dataset JSON response; set to false to remove"
+        ),
+    ] = True
 
 
 @dataclass
@@ -91,94 +93,128 @@ class QueryFilters:
 
     # date filters all use our custom FormIn data type, this allows empty strings to be submitted as parameter values
     # this does not need to be used for required parameters or path parameters
-    start_date: Optional[datetime.date] = Query(None, include_in_schema=False)
-    start_date_year: Optional[FormInt] = Query(
-        None,
-        description="""
+    start_date: Annotated[
+        Optional[datetime.date], Query(include_in_schema=False)
+    ] = None
+    start_date_year: Annotated[
+        Optional[FormInt],
+        Query(
+            description="""
         Search for entities by start date year before or after the given year. Depends on start_date_match
-        """,
-    )
-    start_date_month: Optional[FormInt] = Query(
-        None,
-        description="""
+        """
+        ),
+    ] = None
+    start_date_month: Annotated[
+        Optional[FormInt],
+        Query(
+            description="""
         Search for entities by start date month before or after the given year. Depends on start_date_match
-        """,
-    )
-    start_date_day: Optional[FormInt] = Query(
-        None,
-        description="""
+        """
+        ),
+    ] = None
+    start_date_day: Annotated[
+        Optional[FormInt],
+        Query(
+            description="""
         Search for entities by start date day before or after the given day. Depends on start_date_match
-        """,
-    )
-    start_date_match: Optional[DateOption] = Query(
-        None,
-        description="Specify how to filter against the start_date_* values provided, either before, after or match",
-    )
+        """
+        ),
+    ] = None
+    start_date_match: Annotated[
+        Optional[DateOption],
+        Query(
+            description="Specify how to filter against the start_date_* values provided, either before, after or match"
+        ),
+    ] = None
 
-    end_date: Optional[datetime.date] = Query(None, include_in_schema=False)
-    end_date_year: Optional[FormInt] = Query(
-        None,
-        description="""Search by end date year before or after the given year. Depends on end_date_match""",
-    )
-    end_date_month: Optional[FormInt] = Query(
-        None,
-        description="""
+    end_date: Annotated[Optional[datetime.date], Query(include_in_schema=False)] = None
+    end_date_year: Annotated[
+        Optional[FormInt],
+        Query(
+            description="""Search by end date year before or after the given year. Depends on end_date_match"""
+        ),
+    ] = None
+    end_date_month: Annotated[
+        Optional[FormInt],
+        Query(
+            description="""
         Search for entities by end date month before or after the given month.Depends on end_date_match
-        """,
-    )
-    end_date_day: Optional[FormInt] = Query(
-        None,
-        description="""
+        """
+        ),
+    ] = None
+    end_date_day: Annotated[
+        Optional[FormInt],
+        Query(
+            description="""
         Search for entities by end date day before or after the given day. Depends on end_date_match
-        """,
-    )
-    end_date_match: Optional[DateOption] = Query(
-        None,
-        description="""Specify how to filter against the end_date_* values provided, either before, after or match""",
-    )
+        """
+        ),
+    ] = None
+    end_date_match: Annotated[
+        Optional[DateOption],
+        Query(
+            description="""
+        Specify how to filter against the end_date_* values provided, either before, after or match
+        """
+        ),
+    ] = None
 
-    entry_date: Optional[datetime.date] = Query(None, include_in_schema=False)
-    entry_date_year: Optional[FormInt] = Query(
-        None,
-        description="""
+    entry_date: Annotated[
+        Optional[datetime.date], Query(include_in_schema=False)
+    ] = None
+    entry_date_year: Annotated[
+        Optional[FormInt],
+        Query(
+            description="""
         Search for entities by entry date year before or after the given year. Depends on entry_date_match
-        """,
-    )
-    entry_date_month: Optional[FormInt] = Query(
-        None,
-        description="""
-        Search for entities for entities by entry date month before or after the given month.Depends on entry_date_match
-        """,
-    )
+        """
+        ),
+    ] = None
+    entry_date_month: Annotated[
+        Optional[FormInt],
+        Query(
+            description="""
+        Search for entities by entry date month before or after the given month. Depends on entry_date_match
+        """
+        ),
+    ] = None
 
-    entry_date_day: Optional[FormInt] = Query(
-        None,
-        description="""
+    entry_date_day: Annotated[
+        Optional[FormInt],
+        Query(
+            description="""
         Search for entities by entry date day before or after the given day. Depends on entry_date_match
-        """,
-    )
-    entry_date_match: Optional[DateOption] = Query(
-        None,
-        description="""
+        """
+        ),
+    ] = None
+    entry_date_match: Annotated[
+        Optional[DateOption],
+        Query(
+            description="""
         Specify for entities how to filter against the entry_date_* values provided, either before, after or match
-        """,
-    )
+        """
+        ),
+    ] = None
 
     # spatial filters
-    longitude: Optional[float] = Query(
-        None,
-        description="""
+    longitude: Annotated[
+        Optional[float],
+        Query(
+            description="""
         Search for entity with geometries intersected by a point constructed with this longitude.
         Requires latitude to be provided.
-        """,
-    )
-    latitude: Optional[float] = Query(
-        None,
-        description="""
+        """
+        ),
+    ] = None
+    latitude: Annotated[
+        Optional[float],
+        Query(
+            description="""
         Search for entities with geometries intersected by a point constructed with this latitude.
         Requires longitude to be provided.
-        """,
-    )
+        """
+        ),
+    ] = None
     geometry: Annotated[
         Optional[List[str]],
         Query(
@@ -197,43 +233,57 @@ class QueryFilters:
     ] = None
     geometry_reference: Annotated[
         Optional[List[str]],
-        Query(description="""
+        Query(
+            description="""
         Search entities with geometries interacting with the geometries of
         entities with the provided references. The type of geometric relation
         can be set using the geometry relation parameter.
-        """),
+        """
+        ),
     ] = None
     geometry_curie: Annotated[
         Optional[List[str]],
-        Query(description="""
+        Query(
+            description="""
         Search for entities with geometries interacting with geometries
         entities matching provided curies. The type of geometric relation
         can be set using the geometry relation parameter.
-        """),
+        """
+        ),
     ] = None
-    geometry_relation: Optional[GeometryRelation] = Query(
-        None, description="DE-9IM spatial relationship, default is 'within'"
-    )
-    q: Optional[str] = Query(
-        None,
-        description="""
+    geometry_relation: Annotated[
+        Optional[GeometryRelation],
+        Query(description="DE-9IM spatial relationship, default is 'within'"),
+    ] = None
+    q: Annotated[
+        Optional[str],
+        Query(
+            description="""
         Search by a postcode, or a Unique Property Reference Number (UPRN).
-        """,
-    )
+        """
+        ),
+    ] = None
 
     # pagination filters
-    limit: Optional[int] = Query(
-        10, description="limit for the number of results", ge=1, le=500
-    )
-    offset: Optional[int] = Query(None, description="paginate results from this entity")
+    limit: Annotated[
+        Optional[int],
+        Query(description="limit for the number of results", ge=1, le=500),
+    ] = 10
+    offset: Annotated[
+        Optional[int], Query(description="paginate results from this entity")
+    ] = None
 
     # response format filters
-    accept: Optional[str] = Header(
-        None, description="accepted content-type for results", include_in_schema=False
-    )
-    suffix: Optional[SuffixEntity] = Query(
-        None, description="file format for the results", include_in_schema=False
-    )
+    accept: Annotated[
+        Optional[str],
+        Header(
+            description="accepted content-type for results", include_in_schema=False
+        ),
+    ] = None
+    suffix: Annotated[
+        Optional[SuffixEntity],
+        Query(description="file format for the results", include_in_schema=False),
+    ] = None
     # once field is updated we can validate this
     field: Annotated[
         Optional[List[str]], Query(description="fields to be included in response")

--- a/application/templates/pages/docs.html
+++ b/application/templates/pages/docs.html
@@ -23,6 +23,11 @@
   {% elif "allOf" in params.parameter['schema'].keys()%}
     {% set _parameterComponentName = params.parameter['schema']["allOf"][0]["$ref"]|extract_component_key %}
     {% set _schema = params.components['schemas'][_parameterComponentName] %}
+  {% elif "anyOf" in params.parameter['schema'].keys() and params.parameter['schema']["anyOf"] | selectattr("$ref", "defined") | list | length > 0 %}
+    {% set _parameterComponentName = (params.parameter['schema']["anyOf"] | selectattr("$ref", "defined") | first)["$ref"]|extract_component_key %}
+    {% set _schema = params.components['schemas'][_parameterComponentName] %}
+  {% elif "anyOf" in params.parameter['schema'].keys() %}
+    {% set _schema = params.parameter["schema"]["anyOf"][0] %}
   {% else %}
     {% set _schema = params.parameter['schema'] %}
   {% endif %}
@@ -36,6 +41,10 @@
 {% macro _parameterDescription(params={}) %}
   {% if "$ref" in params.parameter['schema'].keys() %}
     {% set _parameterComponentName = params.parameter['schema']["$ref"]|extract_component_key %}
+    {% set _schema = params.components['schemas'][_parameterComponentName] %}
+    Must be one of: {{ _schema["enum"][:-1] | join(", ") }} or {{ _schema["enum"] | last }}
+  {% elif "anyOf" in params.parameter['schema'].keys() and params.parameter['schema']["anyOf"] | selectattr("$ref", "defined") | list | length > 0 %}
+    {% set _parameterComponentName = (params.parameter['schema']["anyOf"] | selectattr("$ref", "defined") | first)["$ref"]|extract_component_key %}
     {% set _schema = params.components['schemas'][_parameterComponentName] %}
     Must be one of: {{ _schema["enum"][:-1] | join(", ") }} or {{ _schema["enum"] | last }}
   {%  else %}

--- a/tests/unit/search/test_filters.py
+++ b/tests/unit/search/test_filters.py
@@ -1,11 +1,43 @@
-from pydantic.error_wrappers import ValidationError
+from fastapi import FastAPI
+from pydantic import ValidationError
 
+from application.routers import dataset, entity
 from application.search.filters import (
     FactPathParams,
     FactQueryFilters,
     FactDatasetQueryFilters,
     QueryFilters,
 )
+
+PARAMS_NOT_REQUIRING_DESCRIPTIONS = {"extension"}
+
+
+def _schema_parameter_descriptions():
+    app = FastAPI()
+    app.include_router(entity.router, prefix="/entity")
+    app.include_router(dataset.router, prefix="/dataset")
+    schema = app.openapi()
+    descriptions = {}
+    for methods in schema["paths"].values():
+        for op in methods.values():
+            for param in op.get("parameters", []):
+                descriptions.setdefault(param["name"], []).append(
+                    param.get("description")
+                )
+    return descriptions
+
+
+def test_documented_parameters_have_descriptions():
+    descriptions = _schema_parameter_descriptions()
+    missing = [
+        name
+        for name, occurrences in descriptions.items()
+        if name not in PARAMS_NOT_REQUIRING_DESCRIPTIONS and not all(occurrences)
+    ]
+    assert (
+        not missing
+    ), f"Parameters missing a description in the OpenAPI schema: {missing}"
+
 
 # removed as typologies checking is not in the main function
 # TODO use integration/acceptance test to do this


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A previous Pythgon migration only partially converted filters.py to the Annotated[...] style FastAPI/Pydantic v2 requires to surface a field's description in the OpenAPI schema. Fields still using the old `Optional[X] = Query(default, description=...)` pattern silently lost their descriptions from /docs and /openapi.json.

This change converts the remaining fields and adds regression tests that build the real OpenAPI schema and assert every documented parameter has a description.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land.info/issues/529

## QA Instructions, Screenshots, Recordings

| Before | After |
|--------|--------|
|  <img width="1022" height="1334" alt="616708730-92c0b884-912f-4e1c-86b9-4d8bb2f6271b" src="https://github.com/user-attachments/assets/3536e4bb-491b-454b-b413-a951a4ad3739" /> | <img width="998" height="1325" alt="Screenshot 2026-07-06 at 11 28 24" src="https://github.com/user-attachments/assets/73d2e6e6-3a0d-4a91-b8cc-568c42621a61" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API documentation rendering for parameters defined using `anyOf`, so “must be one of …” is generated from the referenced component schema.
  * Standardised search filter parameter metadata (dates, location, geometry, pagination, and related response-format fields) for more consistent OpenAPI output.
* **Documentation**
  * Enhanced the docs template logic for resolving `anyOf` schema references when rendering parameter types and descriptions.
* **Tests**
  * Updated OpenAPI-based validation to ensure all visible query filter parameters either have non-empty descriptions or are explicitly allowlisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->