### PR TITLE
WCAG - Heading structure for screen readers on Entity page

### DIFF
--- a/application/templates/components/filter-group/macro.jinja
+++ b/application/templates/components/filter-group/macro.jinja
@@ -1,15 +1,13 @@
 {% macro dlFilterGroup(params) %}
 <details class="dl-filter-group" {% if params.is_open %}open{% endif %} {% if not params.no_count %}data-module="selected-counter"{% endif %}>
-	<summary class="dl-filter-group__summary"><h2 class="govuk-heading-s dl-filter-group__heading">{{ params.title }}</h2>
+	<summary class="dl-filter-group__summary"><h3 class="govuk-heading-s dl-filter-group__heading">{{ params.title }}</h3>
 		{%- if params.selected %}<span class="dl-filter-group__selected-text"><span class="dl-filter-group__selected-text__count">{{ params.selected }}</span> selected</span>{% endif -%}
 		<svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="dl-filter-group__icon dl-filter-group__icon--up"><path d="m798.16 609.84l-256-256c-16.683-16.683-43.691-16.683-60.331 0l-256 256c-16.683 16.683-16.683 43.691 0 60.331s43.691 16.683 60.331 0l225.84-225.84 225.84 225.84c16.683 16.683 43.691 16.683 60.331 0s16.683-43.691 0-60.331z"></path></svg>
 		<svg version="1.1" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" class="dl-filter-group__icon dl-filter-group__icon--down"><path d="m225.84 414.16l256 256c16.683 16.683 43.691 16.683 60.331 0l256-256c16.683-16.683 16.683-43.691 0-60.331s-43.691-16.683-60.331 0l-225.84 225.84-225.84-225.84c-16.683-16.683-43.691-16.683-60.331 0s-16.683 43.691 0 60.331z"></path></svg>
 	</summary>
 	<fieldset class="govuk-fieldset dl-filter-group__fieldset">
 		<legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">
-		  <h1 class="govuk-fieldset__heading">
 			{{ params.title }}
-		  </h1>
 		</legend>
 		{{ caller() }}
 	</fieldset>

--- a/application/templates/fact-search.html
+++ b/application/templates/fact-search.html
@@ -16,7 +16,7 @@
           <span class="govuk-caption-xl">
             <a href="/curie/{{entity_prefix}}:{{entity_reference}}" class="govuk-link">{%  if entity_name %}{{entity_name}}{% else %}{{entity_prefix}}:{{entity_reference}}{% endif %}</a>
           </span>
-          <div class="govuk-heading-xl">Provenance</div>
+          <h1 class="govuk-heading-xl">Provenance</h1>
         </div>
         <div class="govuk-grid-column-one-third">
           {% set fact_search_form_url = "/fact" %}

--- a/application/templates/partials/fact-search-facets.html
+++ b/application/templates/partials/fact-search-facets.html
@@ -4,7 +4,7 @@
 
 <form action="{{ fact_search_form_url }}" method="get">
 
-  <h3 class="govuk-heading-m">Filters</h3>
+  <h2 class="govuk-heading-m">Filters</h2>
 
   <!-- dataset facet -->
   <div class="govuk-form-group">

--- a/application/templates/partials/search-facets.html
+++ b/application/templates/partials/search-facets.html
@@ -86,11 +86,11 @@
     <div class="govuk-form-group">
         {% set search_query = query.params.get("q", "") %}
         <div class="dl-filter-group">
-            <h2 class="dl-filter-group__heading govuk-heading-s">
+            <h3 class="dl-filter-group__heading govuk-heading-s">
                 <label class="govuk-label govuk-label--s" for="find-an-area">
                     Postcode or Unique Property Reference Number (UPRN)
                 </label>
-            </h2>
+            </h3>
             <div class="app-filter-group__body">
                 <input class="govuk-input dl-filter-group__auto-filter__input" id="find-an-area" name="q" type="text"
                        spellcheck="false"
@@ -117,7 +117,7 @@
       {% endset %}
       {% call dlFilterGroup({
           "title": "Organisation",
-          "is_open": True if query.params.get('organisation_entity') else False,
+              "is_open": True if query.params.get('organisation_entity') else False,
           "selected": query.params.get('organisation_entity')|length if query.params.get('organisation_entity') else 0
         }) %}
         {{ dlFilterCheckboxes({
@@ -158,15 +158,13 @@
 
   <!-- filter by entry date -->
   <div class="dl-filter-group govuk-!-margin-bottom-6">
-    <h2 class="dl-filter-group__heading govuk-heading-s">Entry date</h2>
+    <h3 class="dl-filter-group__heading govuk-heading-s">Entry date</h3>
     <div class="app-filter-group__body">
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" role="group" aria-describedby="entry-date-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-            <h1 class="govuk-fieldset__heading govuk-visually-hidden">
-              Which date are you interested in?
-            </h1>
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-visually-hidden">
+            Which date are you interested in?
           </legend>
           <div id="entry-date-hint" class="govuk-hint">
             For example, 27 3 2021
@@ -202,10 +200,8 @@
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-            <h1 class="govuk-fieldset__heading govuk-visually-hidden">
-              Do you want to see entries since the date or after the date?
-            </h1>
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-visually-hidden">
+            Do you want to see entries since the date or after the date?
           </legend>
           <div class="govuk-radios">
             <div class="govuk-radios__item">


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

Context:
The heading structure on the page is confusing for screen reader users. There are multiple H1 headings and subheadings that do not follow a logical hierarchy. Screen reader users expect a single H1 per page and a clear, hierarchical structure to navigate efficiently. The filter section uses H2 for 'Filters', but subheadings like 'Typology' and 'Dataset' are also H2, and some headings are only announced when details components are expanded.

Changes:
- Update heading structure for the Entity page

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/699

## QA Instructions, Screenshots, Recordings

| Before | After |
|--------|--------|
| <img width="1023" height="893" alt="Screenshot 2026-07-09 at 14 25 37" src="https://github.com/user-attachments/assets/29762c30-069a-447d-afe7-efc29310a9f1" /> | <img width="1010" height="935" alt="Screenshot 2026-07-09 at 14 25 21" src="https://github.com/user-attachments/assets/c9dab85b-b739-4873-bc20-7aedb3ee8e7a" /> | 
| <img width="1005" height="848" alt="Screenshot 2026-07-10 at 09 42 54" src="https://github.com/user-attachments/assets/0b04b8b9-60d6-4928-998e-4383e1aec045" /> | <img width="1008" height="694" alt="Screenshot 2026-07-10 at 09 44 44" src="https://github.com/user-attachments/assets/39d967d9-606c-4d06-b756-8ca9e7e2ff60" /> |

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the heading hierarchy and accessibility markup across filter panels, ensuring consistent structure.
  * Updated filter facet headings and legends (including postcode, entry date, and related radio options) to display correctly within the search and facets UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->