### PR TITLE
WCAG - Selected filter hierarchy on Enity page

### DIFF
--- a/application/templates/fact-search.html
+++ b/application/templates/fact-search.html
@@ -51,9 +51,10 @@
             <div class="app-applied-filters">
               {% if query_params and query_params.get('field') %}
               <div class="app-applied-filter__group">
-                <span class="app-applied-filter__name govuk-!-font-weight-bold">Fields:</span>
+                <h3 class="app-applied-filter__name">Fields:</h3>
+                <ul class="app-applied-filter__list">
                 {% for filter in query_params.get('field') %}
-                <span class="app-applied-filter__item">
+                <li class="app-applied-filter__item">
                   {{ removeFilterButton({
                     "filter": {
                       "name": "field",
@@ -61,8 +62,9 @@
                     },
                     "url": "?" + query_params|make_url_param_str({"field":filter})
                   }) }}
-                </span>
+                </li>
                 {% endfor %}
+                </ul>
               </div>
               {% endif %}
             </div>

--- a/application/templates/search.html
+++ b/application/templates/search.html
@@ -47,7 +47,7 @@
         <div class="app-results-summary">
           <h2 class="app-results-summary__title">{{ count|commanum }} result{{ "" if count == 1 else "s" }}</h2>
           {% macro removeFilterButton(params) %}
-          <a href="{{ params.url }}" class="app-applied-filter__button govuk-link" arial-label="Remove filter for {{ params.filter.name }}">
+          <a href="{{ params.url }}" class="app-applied-filter__button govuk-link" aria-label="Remove filter for {{ params.filter.name }}">
             <span class="app-facet-tag__icon" aria-hidden="true">
               <svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -69,9 +69,10 @@
           <div class="app-applied-filters">
             {% if query.params and query.params.get('typology') %}
             <div class="app-applied-filter__group">
-              <span class="app-applied-filter__name govuk-!-font-weight-bold">Typology:</span>
+              <h3 class="app-applied-filter__name">Typology:</h3>
+              <ul class="app-applied-filter__list">
               {% for filter in query.params.get('typology') %}
-              <span class="app-applied-filter__item">
+              <li class="app-applied-filter__item">
                 {{ removeFilterButton({
                   "filter": {
                     "name": "typology",
@@ -79,15 +80,17 @@
                   },
                   "url": "?" + filter|make_param_str('typology', url_query_params.list)
                 }) }}
-              </span>
+              </li>
               {% endfor %}
+              </ul>
             </div>
             {% endif %}
             {% if query.params and query.params.get('dataset') %}
             <div class="app-applied-filter__group">
-              <span class="app-applied-filter__name govuk-!-font-weight-bold">Dataset:</span>
+              <h3 class="app-applied-filter__name">Dataset:</h3>
+              <ul class="app-applied-filter__list">
               {% for filter in query.params.get('dataset') %}
-              <span class="app-applied-filter__item">
+              <li class="app-applied-filter__item">
                 {{ removeFilterButton({
                   "filter": {
                     "name": "dataset",
@@ -95,16 +98,18 @@
                   },
                   "url": "?" + filter|make_param_str("dataset", url_query_params.list)
                 }) }}
-              </span>
+              </li>
               {% endfor %}
+              </ul>
             </div>
             {% endif %}
             {% if query.params and query.params.get('geometry_curie') %}
             <div class="app-applied-filter__group">
-              <span class="app-applied-filter__name govuk-!-font-weight-bold">Local Authority District:</span>
+              <h3 class="app-applied-filter__name">Local Authority District:</h3>
+              <ul class="app-applied-filter__list">
               {% if query.params.get('geometry_curie')|is_list %}
                 {% for filter in query.params.get('geometry_curie') %}
-                <span class="app-applied-filter__item">
+                <li class="app-applied-filter__item">
                   {{ removeFilterButton({
                     "filter": {
                       "name": "geometry_curie",
@@ -112,10 +117,10 @@
                     },
                     "url": "?" + filter|make_param_str('geometry_curie', url_query_params.list)
                   }) }}
-                </span>
+                </li>
                 {% endfor %}
               {% else %}
-              <span class="app-applied-filter__item">
+              <li class="app-applied-filter__item">
                 {{ removeFilterButton({
                   "filter": {
                     "name": "geometry_curie",
@@ -123,14 +128,15 @@
                   },
                   "url": "?" + query.params.get('geometry_curie')|make_param_str('geometry_curie', url_query_params.list)
                 }) }}
-              </span>
+              </li>
               {% endif %}
+              </ul>
             </div>
             {% endif %}
 
             {% if query.params and query.params.get('q') %}
             <div class="app-applied-filter__group">
-              <span class="app-applied-filter__name govuk-!-font-weight-bold">
+              <h3 class="app-applied-filter__name">
                 {% if find_an_area_result and find_an_area_result.get('type') == 'uprn' %}
                   UPRN:
                 {% elif query.params.get('q') %}
@@ -138,8 +144,9 @@
                 {% else %}
                   Area:
                 {% endif %}
-              </span>
-              <span class="app-applied-filter__item">
+              </h3>
+              <ul class="app-applied-filter__list">
+              <li class="app-applied-filter__item">
                 {{ removeFilterButton({
                   "filter": {
                     "name": "area",
@@ -147,16 +154,18 @@
                   },
                   "url": "?" + query.params|make_url_param_str(exclude_params=['q', 'latitude', 'longitude'])
                 }) }}
-              </span>
+              </li>
+              </ul>
             </div>
             {% endif %}
 
             {% if query.params and query.params.get('organisation_entity') %}
               <div class="app-applied-filter__group">
-                <span class="app-applied-filter__name govuk-!-font-weight-bold">Organisation:</span>
+                <h3 class="app-applied-filter__name">Organisation:</h3>
+                <ul class="app-applied-filter__list">
                   {% for filter in query.params.get('organisation_entity') %}
                     {% set str_org_entity = filter | string %}
-                    <span class="app-applied-filter__item">
+                    <li class="app-applied-filter__item">
                       {{ removeFilterButton({
                       "filter": {
                       "name": "organisation_entity",
@@ -164,16 +173,18 @@
                       },
                       "url": "?" + str_org_entity|make_param_str('organisation_entity', url_query_params.list)
                       }) }}
-                    </span>
+                    </li>
                   {% endfor %}
+                </ul>
               </div>
             {% endif %}
 
             {% if query.params and query.params.get('period') %}
             <div class="app-applied-filter__group">
-              <span class="app-applied-filter__name govuk-!-font-weight-bold">Period:</span>
+              <h3 class="app-applied-filter__name">Period:</h3>
+              <ul class="app-applied-filter__list">
               {% for filter in query.params.get('period') %}
-                <span class="app-applied-filter__item">
+                <li class="app-applied-filter__item">
                   {{ removeFilterButton({
                     "filter": {
                       "name": "period",
@@ -181,15 +192,17 @@
                     },
                     "url": "?" + filter|make_param_str("period", url_query_params.list)
                   }) }}
-                </span>
+                </li>
               {% endfor %}
+              </ul>
             </div>
             {% endif %}
 
             {% if query.params and query.params.get('entry_date_match') %}
             <div class="app-applied-filter__group">
-              <span class="app-applied-filter__name govuk-!-font-weight-bold">Entries:</span>
-              <span class="app-applied-filter__item">
+              <h3 class="app-applied-filter__name">Entries:</h3>
+              <ul class="app-applied-filter__list">
+              <li class="app-applied-filter__item">
                 {{ removeFilterButton({
                   "filter": {
                     "name": "entries",
@@ -197,7 +210,8 @@
                   },
                   "url": "#"
                 }) }}
-              </span>
+              </li>
+              </ul>
             </div>
             {% endif %}
           </div>

--- a/assets/stylesheets/component/_applied-filters.scss
+++ b/assets/stylesheets/component/_applied-filters.scss
@@ -17,6 +17,15 @@
 
 .app-applied-filter__name {
   display: inline-block;
+  margin: 0;
+  font-size: inherit;
+}
+
+.app-applied-filter__list {
+  display: inline;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .app-applied-filter__item {

--- a/tests/unit/routers/test_entity.py
+++ b/tests/unit/routers/test_entity.py
@@ -1060,7 +1060,7 @@ def test_search_entities_area_chip_remove_link_clears_area_params(
     rendered = result.template.render(result.context)
     soup = BeautifulSoup(rendered, "html.parser")
     area_label = soup.find(
-        "span",
+        "h3",
         string=lambda text: text is not None and "Postcode:" in text,
     )
     assert area_label is not None


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

For WCAG 2.2 conformance.

Below the h2 heading ‘Results’, there are visually styled headings ‘Dataset’ and ‘Local Authority District’ that introduce filtered terms. These headings are not marked up programmatically using heading tags, so screen reader users cannot identify the structure and hierarchy as sighted users do. Additionally, the links under these headings are not presented in lists, making it difficult for screen reader users to associate the links with each other or with the headings.

Changes:
- Fix typo in aria-label
- Move selected filter section titles into headings
- Modify the structure so that the selected filters are within a list, and within the same group as the heading.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/700

## QA Instructions, Screenshots, Recordings

| Before | After |
|--------|--------|
| <img width="1008" height="690" alt="Screenshot 2026-07-10 at 15 12 00" src="https://github.com/user-attachments/assets/4799e71c-1762-4ff3-a6ad-8809b69e5eb9" /> | <img width="1000" height="669" alt="Screenshot 2026-07-10 at 15 04 00" src="https://github.com/user-attachments/assets/04dc1232-7448-4e62-a796-8a865230d274" /> |
| <img width="1009" height="681" alt="Screenshot 2026-07-10 at 15 11 20" src="https://github.com/user-attachments/assets/812e637c-fa8c-4dea-9421-4be7f89f9ea9" /> | <img width="992" height="688" alt="Screenshot 2026-07-10 at 15 08 46" src="https://github.com/user-attachments/assets/a8e55edc-d0ff-4aca-8fa0-e619f078cf17" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: _Changes to HTML and CSS only_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Corrected filter-removal controls so screen readers can identify them properly.

* **UI Improvements**
  * Reworked applied-filter displays with clearer headings and list-based layouts.
  * Preserved existing filter removal behaviour and displayed values.
  * Updated styling to keep filter lists compact and consistently formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->