### PR TITLE
Bug: Curies with single digit reference failing in endpoint

### DIFF
--- a/application/search/validators.py
+++ b/application/search/validators.py
@@ -53,7 +53,7 @@ def validate_curies(curies: Optional[List[str]]):
         else:
             prefix, reference = parts
             prefix_match = re.match(r"(?i)^[a-zA-Z_\d]+[a-zA-Z_\-\d]+$", prefix)
-            reference_match = re.match(r"^\S+.*\S$", reference)
+            reference_match = re.match(r"^\S(.*\S)?$", reference)
             if prefix_match is None or reference_match is None:
                 raise DigitalLandValidationError(
                     "curie must be in form 'prefix:reference'"

--- a/tests/unit/search/test_validators.py
+++ b/tests/unit/search/test_validators.py
@@ -104,6 +104,7 @@ def test_validate_year_integer_valid_value_provided():
 
 
 valid_curies = [
+    "prefix:1",
     "prefix:reference",
     "prefix:reference#and-something",
     "PREFIX:REFERENCE",


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A curie is Compact URI comprising of a prefix, delimiter, and a reference. We validate our curies to ensure they're formatted correctly. In this instance it appears to have been overlooked that curies may contain a single digit reference, which left such instances failing validation and returning the error message `curie must be in form 'prefix:reference'` from the API. This change updates the validation to allow single digit references, for example: area-of-outstanding-natural-beauty:5

Changes:
- Update regex to allow single digit references

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/622

## QA Instructions, Screenshots, Recordings

Curies with single digit references should return a successful json response

https://www.planning.data.gov.uk/entity.geojson?curie=area-of-outstanding-natural-beauty:5&extension=geojson

<img width="529" height="353" alt="Screenshot 2026-07-13 at 12 01 11" src="https://github.com/user-attachments/assets/d8c8360c-c2a9-40ec-b8ec-852f410e0a9a" />


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CURIE validation to accept valid single-character references, such as `prefix:1`.
  * Retained existing validation for malformed prefixes, references and formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->