### PR TITLE
WCAG - Table headers in dataset table

### DIFF
--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -73,7 +73,7 @@
         set rows = [
           [
             {
-              'html': '<b>Total</b>',
+              'html': 'Total',
               'attributes': {
                 'style': 'width: 35%'
               }
@@ -84,7 +84,7 @@
           ],
           [
             {
-              'html': '<b>Data providers</b>',
+              'html': 'Data providers',
             },
             {
               'html': publishers['current']|commanum,
@@ -92,7 +92,7 @@
           ],
           [
             {
-              'html': '<b>Collector last ran on</b>'
+              'html': 'Collector last ran on'
             },
             {
               'html': last_collection_attempt if last_collection_attempt else 'no attempt'
@@ -100,7 +100,7 @@
           ],
           [
             {
-              'html': '<b>New data last found on</b>'
+              'html': 'New data last found on'
             },
             {
               'html': latest_resource.last_updated if latest_resource.last_updated else 'N/A'
@@ -108,7 +108,7 @@
           ],
           [
             {
-              'html': '<b>Origin</b>'
+              'html': 'Origin'
             },
             {
               'html': dataset_origin_label
@@ -121,7 +121,7 @@
         {{
           rows.append([
             {
-              'html': '<b>Licence</b>'
+              'html': 'Licence'
             },
             {
               'html': dataset.licence_text | render_markdown(govAttributes=True)
@@ -134,7 +134,7 @@
         {{
           rows.append([
             {
-              'html': '<b>Attribution</b>'
+              'html': 'Attribution'
             },
             {
               'html': dataset.attribution_text | render_markdown(govAttributes=True) if dataset.attribution else ''
@@ -147,7 +147,7 @@
         {%- set rows = [
           [
             {
-              'html': '<b>Summary</b>'
+              'html': 'Summary'
             },
             {
               'html': dataset.text | render_markdown(govAttributes=True)
@@ -161,6 +161,7 @@
           'attributes': {
             'aria-label': 'About the dataset'
           },
+          'firstCellIsHeader': true,
           'rows': rows
         })
       }}


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

A table has been used for layout purposes even though there are relationships in content present. When a table does not have any table headers, the content is read by screen reader users in a linear format and the relationships are lost. Adding table header, ensure that screen reader software read in a 2D format so that the relationship in content is relayed. Currently, the table element has no table headers <th>.

Changes:
- Add table headers, scoped to row


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes https://github.com/digital-land/digital-land/issues/702

## QA Instructions, Screenshots, Recordings

| Before | After |
|--------|--------|
| <img width="1124" height="478" alt="Screenshot 2026-07-13 at 15 46 02" src="https://github.com/user-attachments/assets/6debfc02-16d6-490a-ae3f-778e298f52f5" /> | <img width="1441" height="732" alt="Screenshot 2026-07-13 at 15 47 11" src="https://github.com/user-attachments/assets/60ff5f86-0d9a-45ff-bd57-5016f83bffa6" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: _I've investigated various ways to cleanly test these small a11y updates but they generally come with a burden of large tests focusing on implementation detail and they will not prevent the same issues being introduced elsewhere or if implementation is changed. The version history documents a11y requirements in current implementation_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved table semantics in the “About this dataset” section so row labels are correctly identified for assistive technologies.
  * Updated label presentation for a cleaner, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->