### PR TITLE
WCAG 2.2 Accessibility - Info and Relationships

### DIFF
--- a/application/templates/components/entity-card/macro.jinja
+++ b/application/templates/components/entity-card/macro.jinja
@@ -22,11 +22,7 @@
             <div class="app-card__header__secondary">
             <label id="typologyLabel" class="govuk-visually-hidden">Typology type</label>
             <p class="govuk-body govuk-hint govuk-!-margin-0" aria-labelledby="typologyLabel" title="Typology type">{{ e["typology"] | capitalize }}</p>
-            <dl class="app-card__datalist">
-                <div class="app-card__datalist__row">
-                <dd class="app-card__datalist__value"><a href="{{ e['entity'] }}/" class="govuk-link">{{ e["reference"] }}</a></dd>
-                </div>
-            </dl>
+            <a href="/entity/{{ e['entity'] }}" class="govuk-link app-card__reference">{{ e["reference"] }}</a>
             </div>
         </div>
 

--- a/application/templates/pages/docs.html
+++ b/application/templates/pages/docs.html
@@ -79,6 +79,7 @@
 
   {% call appSummaryCard({
       'titleText': params.name,
+      'headingLevel': '3',
       'classes': 'govuk-!-margin-bottom-6',
       'attributes': [
         ['aria-label', params.name]

--- a/assets/javascripts/LayerControls.js
+++ b/assets/javascripts/LayerControls.js
@@ -52,16 +52,16 @@ export default class LayerControls {
       heading.classList.add('dl-map__side-panel__heading');
       settingsPanelHeading.classList.add('dl-map__side-panel__heading');
 
-      const h3 = document.createElement('h3');
-      const settingsPanelh3 = document.createElement('h3');
+      const primaryPanelHeadingElement = document.createElement('h2');
+      const settingsPanelHeadingElement = document.createElement('h2');
 
-      h3.classList.add('govuk-heading-s', 'govuk-!-margin-bottom-0');
-      h3.textContent = 'Data layers';
-      settingsPanelh3.classList.add('govuk-heading-s', 'govuk-!-margin-bottom-0');
-      settingsPanelh3.textContent = 'Settings';
+      primaryPanelHeadingElement.classList.add('govuk-heading-s', 'govuk-!-margin-bottom-0');
+      primaryPanelHeadingElement.textContent = 'Data layers';
+      settingsPanelHeadingElement.classList.add('govuk-heading-s', 'govuk-!-margin-bottom-0');
+      settingsPanelHeadingElement.textContent = 'Settings';
 
-      heading.appendChild(h3);
-      settingsPanelHeading.appendChild(settingsPanelh3);
+      heading.appendChild(primaryPanelHeadingElement);
+      settingsPanelHeading.appendChild(settingsPanelHeadingElement);
 
       sidePanel.appendChild(heading);
       settingsPanel.appendChild(settingsPanelHeading);

--- a/assets/stylesheets/component/_card.scss
+++ b/assets/stylesheets/component/_card.scss
@@ -37,21 +37,11 @@
 	border-bottom: 1px solid $govuk-border-colour;
 }
 
-.app-card__datalist {
+.app-card__reference {
 	margin: 0;
 	font-family: $govuk-font-family;
 	color: govuk-colour('dark-grey');
-	&__row {
-		display: flex;
-		align-items: center;
-		justify-content: flex-start;
-		gap: .25em;
-	}
-	.app-card__datalist__key,
-	.app-card__datalist__value {
-		margin: 0;
-    @include govuk-font($size: 19);
-	}
+	@include govuk-font($size: 19);
 }
 
 .app-card__media {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

#### WCAG - DAC 03 Info and Relationships

Map panel headings

The programmatic heading structure on the page does not represent the
visual structure and hierarchy of the page for screen reader users. In
this case, below the h2 heading ‘Find an area’ is a h3 heading on the
map ‘Data layers’ this indicates to screen reader users that it is a
sub-heading of the h2 when it is not related and is an independent
section of the page and should also be marked up as a h2 heading for
screen reader users to identify the structure and hierarchy of the page
in the same way as a sighted user.

change includes small refactor of variable names as they were confusing
to read using different conventions for data layer and settings panels,
and the names directly tied to values which makes them more difficult to
update.

Changes:
- Update panel headings to h2 from h3
- Refactor variable names so they're not directly tied to values

#### WCAG - DAC 06 Info and Relationships

Heading hierarchy in endpoint summary cards on API Docs page.

The heading structure on the page may be confusing for screen reader
users who use headings to identify and navigate the structure of the
page using headings. In this case, toward the end of the page there is a
h2 heading ‘Planning data API’ below the heading are a series of visual
sub-headings, but they have also been marked up at h2. This issue may
affect screen reader users who use headings to identify and navigate the
structure of the page using headings and would expect the heading
structure to be logical and hierarchical, representing the visual
structure on the page.

Changes:
- Update summartu card heading from default h2 to h3

#### WCAG - DAC 07 Info and Relationships

Remove incorrectly used description list on Entity page

A description list inside the card header is not complete and does not
contain the `<dt>` element. This breaks the structure of the list and uses
incorrect parent / child relationships which may affect how screen
reading software reads the list.

The original PR does not tell us why it was implemented this way but it
appears that it the markup may have been copy and pasted from other
parts of the page where it is implemented correctly with the required
child elements for terms and descriptions.

Changes:
- Remove definition list from reference
  - Update CSS for new markup

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/701
- Closes https://github.com/digital-land/digital-land/issues/704
- Closes https://github.com/digital-land/digital-land/issues/705



## QA Instructions, Screenshots, Recordings

DAC 03

| Before | After |
|--------|--------|
| <img width="597" height="695" alt="Screenshot 2026-07-15 at 13 41 45" src="https://github.com/user-attachments/assets/0e568346-9a30-499e-9ccf-c8dc5378a146" /> | <img width="567" height="629" alt="Screenshot 2026-07-15 at 13 42 16" src="https://github.com/user-attachments/assets/17ad2cee-825e-4c0f-92b2-20265d004984" /> |

DAC 06

| Before | After |
|--------|--------|
| <img width="387" height="261" alt="Screenshot 2026-07-15 at 13 58 01" src="https://github.com/user-attachments/assets/f2a140e0-5cf6-4bec-9c1e-f45c1e55f55b" /> | <img width="331" height="246" alt="Screenshot 2026-07-15 at 13 58 26" src="https://github.com/user-attachments/assets/beeb4f97-e7be-4dce-abe2-330b30c49837" /> | 

DAC 07

| Before | After |
|--------|--------|
| <img width="1127" height="236" alt="Screenshot 2026-07-15 at 13 54 53" src="https://github.com/user-attachments/assets/4101306f-f8d2-43b7-bac1-38eed06ed29c" /> | <img width="1159" height="241" alt="Screenshot 2026-07-15 at 13 54 23" src="https://github.com/user-attachments/assets/57878501-f265-450c-be41-6baf421c8111" /> | 



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: _Markup and refactoring only_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved heading hierarchy across documentation and map controls to provide a clearer page structure for assistive technologies.
* **Visual Improvements**
  * Updated entity card “Reference” links to appear more directly and consistently in the card header.
  * Refined reference styling for improved readability and alignment with GOV.UK design patterns.
  * Adjusted map control panel heading markup while keeping the existing “Data layers” and “Settings” labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->