### PR TITLE
WCAG 2.2 Accessibility - No Visible Labels

### DIFF
--- a/application/templates/components/map-find-an-area-form/macro.jinja
+++ b/application/templates/components/map-find-an-area-form/macro.jinja
@@ -33,18 +33,20 @@
 
     {# Search controls row: select + inputs placed inline; visibility toggled with JS via .js-hidden #}
     <div class="dl-find-an-area-controls">
-      <label class="govuk-label govuk-label--s govuk-visually-hidden" for="select-method">Search method</label>
+      <div id="select-method-container">
+        <label class="govuk-label govuk-label--s" for="select-method">Search method</label>
 
-      {# Use name="type" so native (non-JS) form submissions send the expected query param #}
-      <select class="govuk-select" id="select-method" name="type">
-        <option value="postcode" {{ 'selected' if selected_sort == 'postcode' else '' }}>Postcode</option>
-        <option value="uprn" {{ 'selected' if selected_sort == 'uprn' else '' }}>UPRN</option>
-        <option value="lpa" {{ 'selected' if selected_sort == 'lpa' else '' }}>Local Planning Authority</option>
-      </select>
+        {# Use name="type" so native (non-JS) form submissions send the expected query param #}
+        <select class="govuk-select" id="select-method" name="type">
+          <option value="postcode" {{ 'selected' if selected_sort == 'postcode' else '' }}>Postcode</option>
+          <option value="uprn" {{ 'selected' if selected_sort == 'uprn' else '' }}>UPRN</option>
+          <option value="lpa" {{ 'selected' if selected_sort == 'lpa' else '' }}>Local Planning Authority</option>
+        </select>
+      </div>
 
       {# Non LPA search input: visible when type == 'postcode' or type == 'uprn' #}
       <div id="postcode-container">
-        <label class="govuk-label govuk-label--s govuk-visually-hidden" for="postcode-input">Postcode</label>
+        <label class="govuk-label govuk-label--s" for="postcode-input">Postcode</label>
         <input id="postcode-input" class="govuk-input govuk-input--width-20 {% if error %}govuk-input--error{% endif %}" name="q" type="text" spellcheck="false" aria-describedby="find-an-area-hint" value="{{ search_query or '' }}">
 
         {# Include any additional hidden fields for URL query parameters, without "q" #}
@@ -57,7 +59,7 @@
 
       {# UPRN search input: visible when type == 'uprn' #}
       <div id="uprn-container" class="js-hidden">
-        <label class="govuk-label govuk-label--s govuk-visually-hidden" for="uprn-search-input">UPRN</label>
+        <label class="govuk-label govuk-label--s" for="uprn-search-input">UPRN</label>
         <input id="uprn-search-input" class="govuk-input govuk-input--width-20 {% if error %}govuk-input--error{% endif %}" name="q" type="text" spellcheck="false" aria-describedby="find-an-area-hint" value="{{ search_query or '' }}">
 
         {# Include any additional hidden fields for URL query parameters, without "q" #}
@@ -70,7 +72,7 @@
 
       {# LPA type-search input: visible when type == 'lpa'. Uses same name 'q' so form submission works. #}
       <div id="lpa-container" class="js-hidden">
-        <label class="govuk-label govuk-label--s govuk-visually-hidden" for="lpa-autocomplete-input">Local planning authority</label>
+        <label class="govuk-label govuk-label--s" for="lpa-autocomplete-input">Local planning authority</label>
         <input id="lpa-autocomplete-input" class="govuk-input govuk-input--width-20 {% if error %}govuk-input--error{% endif %}" type="text" name="q" aria-describedby="find-an-area-hint" autocomplete="off" value="{{ search_query or '' }}">
 
         {# Include any additional hidden fields for URL query parameters, without "q" #}

--- a/application/templates/partials/search-facets.html
+++ b/application/templates/partials/search-facets.html
@@ -163,7 +163,7 @@
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" role="group" aria-describedby="entry-date-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-visually-hidden">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
             Which date are you interested in?
           </legend>
           <div id="entry-date-hint" class="govuk-hint">
@@ -200,7 +200,7 @@
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s govuk-visually-hidden">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
             Do you want to see entries since the date or after the date?
           </legend>
           <div class="govuk-radios">

--- a/assets/stylesheets/pages/_map.scss
+++ b/assets/stylesheets/pages/_map.scss
@@ -5,23 +5,23 @@
 }
 
 .dl-find-an-area-form .dl-find-an-area-controls {
-  display: inline-block;
-  margin-right: 15px;
-  // align-items: center;
-  // gap: govuk-spacing(3);
-  // flex-wrap: wrap;
+  display: flex;
+  align-items: flex-end;
+  gap: govuk-spacing(3);
+  flex-wrap: wrap;
 }
 
 .dl-find-an-area-form .dl-find-an-area-controls .govuk-select {
   min-width: 12rem;
 }
 
+.dl-find-an-area-form #select-method-container,
 .dl-find-an-area-form #postcode-container,
 .dl-find-an-area-form #uprn-container,
 .dl-find-an-area-form #lpa-container {
-  /* allow inputs to appear inline next to the select */
-  display: inline-block;
-  margin-left: 10px;
+  /* stack each control's label above its input, aligned as a row via the flex parent */
+  display: flex;
+  flex-direction: column;
 }
 
 /* Suggestions container for LPA autocomplete: force a full-width row under controls */


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

For WCAG 2.2 Accessibility optimisation

#### WCAG - DAC 01 No Visible Label

Legends not visible in Entry Date form on Entity page

Below the ‘Entry date’ section are two groups of input fields which have
visually hidden legend elements. Whilst the legends are useful for
screen reader users, voice activation users are unable to identify the
questions being asked for each group of input fields and may be unable
to make enter correct data as a result. Removing the visually hidden
class enables voice activation users to understand the questions being
asked related to the groups of input fields.

Changes:
- Remove visually hidden class

#### WCAG - DAC 02 No Visible Label

Visually hidden labels on Find an area form on maps page

The input fields below the h2 heading ‘Find an area’ have labels but
they have been visually hidden. This issue may affect voice activation
users who may be unable to reference the input fields with no visible
label present. This change ensures visible labels are exposed to enable
voice activation users to reference the input fields by their visible
labels

Changes:
- Expose labels to all users
  - Update CSS so that the now visual labels are correctly aligned

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/706
- Closes https://github.com/digital-land/digital-land/issues/707

## QA Instructions, Screenshots, Recordings

https://www.planning.data.gov.uk/entity/

| Before | After |
|--------|--------|
| <img width="1044" height="454" alt="Screenshot 2026-07-16 at 09 41 52" src="https://github.com/user-attachments/assets/ed060f5a-83b3-4978-8fa2-476e2fa8e581" /> | <img width="1057" height="556" alt="Screenshot 2026-07-16 at 09 41 26" src="https://github.com/user-attachments/assets/b867fdc4-6d7e-4683-a8cc-dd8331d5ec22" /> |

https://www.planning.data.gov.uk/map/?

| Before | After |
|--------|--------|
| <img width="1271" height="721" alt="Screenshot 2026-07-16 at 09 40 56" src="https://github.com/user-attachments/assets/ddb9b3f2-4da0-4230-afce-f5ffe67e4261" /> | <img width="1256" height="746" alt="Screenshot 2026-07-16 at 09 41 03" src="https://github.com/user-attachments/assets/274231dc-9ba2-49ad-9c19-e665db5ecd52" /> |

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Made search method and map search fields easier to identify with visible labels.
  * Made entry date filter descriptions visible for clearer navigation.

* **Style**
  * Improved the map search form layout, aligning controls consistently and allowing them to wrap on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->