### PR TITLE
WCAG 2.2 Accessibility - Screen Reader Focus Order

### DIFF
--- a/application/templates/components/entity-card/macro.jinja
+++ b/application/templates/components/entity-card/macro.jinja
@@ -10,15 +10,8 @@
     %}
 
     <li class="app-results-list__item">
-        <article class="app-card app-card--result">
+        <section class="app-card app-card--result">
         <div class="app-card__header">
-            <div class="app-card__header__primary">
-            <h3 class="app-card__title">
-                {% if e["name"] is not none %}
-                    {{ e["name"] }}
-                {% endif %}
-            </h3>
-            </div>
             <div class="app-card__header__secondary">
             <label id="typologyLabel" class="govuk-visually-hidden">Typology type</label>
             <p class="govuk-body govuk-hint govuk-!-margin-0" aria-labelledby="typologyLabel" title="Typology type">{{ e["typology"] | capitalize }}</p>
@@ -27,6 +20,13 @@
                 <dd class="app-card__datalist__value"><a href="{{ e['entity'] }}/" class="govuk-link">{{ e["reference"] }}</a></dd>
                 </div>
             </dl>
+            </div>
+            <div class="app-card__header__primary">
+            <h3 class="app-card__title">
+                {% if e["name"] is not none %}
+                    {{ e["name"] }}
+                {% endif %}
+            </h3>
             </div>
         </div>
 
@@ -84,7 +84,7 @@
             </div>
             </div>
         </div>
-        </article>
+        </section>
         <!-- /.app-card -->
     </li>
 {% endmacro %}

--- a/assets/stylesheets/component/_card.scss
+++ b/assets/stylesheets/component/_card.scss
@@ -7,7 +7,7 @@
 .app-card__header {
 	display: flex;
 	justify-content: space-between;
-	flex-direction: column-reverse;
+	flex-direction: column;
 
 	&__primary{
 		@include govuk-responsive-padding(5);


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

WCAG 2.2 Accessibility optimisation

**Update focus order of title in summary card on entity page**

When screen reader users encounter the planning and housing data results, the focus order does not match the way the data is presented visually on the page. The order of elements in the DOM does not match the visual sequence, meaning screen reader users encounter the headings initially and then the information above it visually, followed by information below it in the description lists. Additionally, sections are presented inside `<article>` tags, which is an incorrect element type for this type of data and should be used for content such as newspaper
  articles, forum or blog posts.

The original implementation reversed the order of elements via CSS but there's no description in the original PR, so it's not known why it was implemented this way. It may have in itself been for accessibility reasons. This change retains the natural order of elements for all users.

**Changes:**
- Update order of elements in DOM and acknowledge in CSS
- Change article element to section


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/708

## QA Instructions, Screenshots, Recordings

| Before | After |
|--------|--------|
| <img width="1051" height="343" alt="Screenshot 2026-07-16 at 13 46 11" src="https://github.com/user-attachments/assets/c140b0cf-f736-4488-af89-75f4768eb136" /> | <img width="1095" height="202" alt="Screenshot 2026-07-16 at 13 46 40" src="https://github.com/user-attachments/assets/8937c2fe-cc7f-4cd1-a87d-f747c8da65d6" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: _changes to markup only_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated entity card markup for improved semantic structure.
  * Adjusted card header layout to display its contents in the correct order.
  * Reformatted entity card title rendering without changing the displayed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->