### PR TITLE
Add side menu to Entity page

### DIFF
--- a/application/routers/entity.py
+++ b/application/routers/entity.py
@@ -3,7 +3,9 @@ import sentry_sdk
 from urllib.parse import urlencode
 
 from dataclasses import asdict
-from typing import Optional, List, Set, Dict, Union
+from typing import Optional, List, Set, Dict, Union, Tuple
+
+from shapely import wkt as shapely_wkt
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Path, Query
 from fastapi.exceptions import RequestValidationError
@@ -163,6 +165,18 @@ def prepare_geojson(e):
     return geojson
 
 
+def get_entity_lat_lng(e) -> Tuple[Optional[float], Optional[float]]:
+    """Return (lat, lng) decimal degrees for an entity's representative point, or (None, None)."""
+    if not e.point:
+        return None, None
+    try:
+        geom = shapely_wkt.loads(e.point)
+        return geom.y, geom.x  # WKT is "X Y" = lng lat
+    except Exception:
+        logger.exception("Failed to parse entity point WKT", extra={"entity": e.entity})
+        return None, None
+
+
 def handle_entity_response(
     request: Request, e, extension: Optional[SuffixEntity], session: Session
 ):
@@ -201,7 +215,6 @@ def handle_entity_response(
         key: e_dict[key] for key in sorted(e_dict.keys(), key=entity_attribute_sort_key)
     }
     # Add CURIE field to dict and make it first
-    
     e_dict_sorted = {"curie": curie, **e_dict_sorted}
     # Map and re-format the quality value to include a description
     e_dict_sorted = map_entity_quality_to_description(e_dict_sorted)
@@ -216,6 +229,7 @@ def handle_entity_response(
     ]
     dataset_fields = [dataset_field["dataset"] for dataset_field in dataset_fields]
     dataset = get_dataset_query(session, e.dataset)
+    entity_lat, entity_lng = get_entity_lat_lng(e)
     entityLinkFields = [
         "article-4-direction",
         "permitted-development-rights",
@@ -270,6 +284,8 @@ def handle_entity_response(
             "organisation_entity": organisation,
             "organisation_curie": organisation_curie,
             "feedback_form_footer": True,
+            "entity_lat": entity_lat,
+            "entity_lng": entity_lng,
         },
     )
 

--- a/application/templates/components/side-nav/macro.jinja
+++ b/application/templates/components/side-nav/macro.jinja
@@ -1,0 +1,30 @@
+{% macro appSideNav(params={}) %}
+  <aside class="app-related-items" role="complementary" aria-label="Explore and download this data">
+    {% for section in params.get('sections', []) %}
+      {% if not loop.first %}
+        <hr class="govuk-section-break govuk-section-break--m">
+      {% endif %}
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-0" id="{{ section.id }}">
+        {{ section.heading }}
+      </h2>
+      {% if section.hint %}
+        <p class="govuk-hint govuk-!-font-size-14">{{ section.hint }}</p>
+      {% endif %}
+      <nav role="navigation" aria-labelledby="{{ section.id }}">
+        <ul class="govuk-list govuk-!-font-size-16">
+          {% for link in section.links %}
+            <li>
+              <a class="govuk-link" href="{{ link.href }}"
+                {%- for attribute in link.get('attributes', []) %} {{ attribute.key }}="{{ attribute.value }}"{% endfor %}>
+                {%- if link.visuallyHiddenPrefix -%}
+                  <span class="govuk-visually-hidden">{{ link.visuallyHiddenPrefix }}</span>
+                {%- endif -%}
+                {{ link.text }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+    {% endfor %}
+  </aside>
+{% endmacro %}

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -1,5 +1,6 @@
 {% extends "layouts/layout.html" %}
 {% from 'components/summary-card/macro.jinja' import appSummaryCard %}
+{% from 'components/side-nav/macro.jinja' import appSideNav %}
 {% set templateName = 'dl-info/dataset.html' %}
 {%- from "components/back-button/macro.jinja" import dlBackButton %}
 {% from 'govuk_frontend_jinja/components/table/macro.html' import govukTable %}
@@ -199,74 +200,50 @@
     <!-- /. govuk-grid-column -->
 
     <div class="govuk-grid-column-one-third">
-
-      <aside class="app-related-items" role="complementary">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-0" id="view-the-data">
-          View the data
-        </h2>
-        <p class="govuk-hint govuk-!-font-size-14">You can explore this data</p>
-        <nav role="navigation" aria-labelledby="view-the-data">
-          <ul class="govuk-list govuk-!-font-size-16">
-            {% if dataset['typology'] == 'geography' %}
-              <li>
-                <a class="govuk-link" href='/map?dataset={{dataset["dataset"]}}'>On a map</a>
-              </li>
-            {% endif %}
-            <li>
-              <a class="govuk-link" href="/entity?dataset={{dataset["dataset"]}}">As a list</a>
-            </li>
-          </ul>
-        </nav>
-        <hr class="govuk-section-break govuk-section-break--m">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-0" id="download-the-data">
-          Download the data
-        </h2>
-        <p class="govuk-hint govuk-!-font-size-14">You can take a copy of this data as</p>
-        <nav role="navigation" aria-labelledby="download-the-data">
-          <ul class="govuk-list govuk-!-font-size-16">
-            <li>
-              <a class="govuk-link" href="{{ data_file_url }}/dataset/{{ dataset["dataset"] }}.csv"><span class="govuk-visually-hidden">Download this data as </span>CSV</a>
-            </li>
-            <li>
-              <a class="govuk-link" href="{{ data_file_url }}/dataset/{{ dataset['dataset'] }}.json"><span class="govuk-visually-hidden">Download this data as </span>JSON</a>
-            </li>
-            {% if dataset['typology'] == 'geography' %}
-            <li>
-              <a class="govuk-link" href="{{ data_file_url }}/dataset/{{ dataset['dataset'] }}.geojson"><span class="govuk-visually-hidden">Download this data as </span>GeoJSON</a>
-            </li>
-            <li>
-              <a class="govuk-link" href="{{ data_file_url }}/dataset/{{ dataset['dataset'] }}.parquet"><span class="govuk-visually-hidden">Download this data as </span>Parquet</a>
-            </li>
-            {% endif %}
-          </ul>
-        </nav>
-        <hr class="govuk-section-break govuk-section-break--m">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-0" id="specification">
-          Dataset definition
-        </h2>
-        <p class="govuk-hint govuk-!-font-size-14">You can view the definition of this dataset including the list of fields</p>
-        <nav role="navigation" aria-labelledby="specification">
-          <ul class="govuk-list govuk-!-font-size-16">
-            <li>
-              <a class="govuk-link" href="https://digital-land.github.io/specification/dataset/{{ dataset["dataset"] }}">Dataset definition for {{ dataset["name"] }} dataset</a>
-            </li>
-          </ul>
-        </nav>
-        {% if dataset['consideration'] %}
-        <hr class="govuk-section-break govuk-section-break--m">
-        <h2 class="govuk-heading-s govuk-!-margin-bottom-0" id="data-design">
-          Designing the data
-        </h2>
-        <p class="govuk-hint govuk-!-font-size-14">You can see details about how this dataset has been designed for planning.data.gov.uk</p>
-        <nav role="navigation" aria-labelledby="specification">
-          <ul class="govuk-list govuk-!-font-size-16">
-            <li>
-              <a class="govuk-link" href="https://design.planning.data.gov.uk/planning-consideration/{{ dataset['consideration'] }}">{{ dataset['consideration'] }} planning consideration</a>
-            </li>
-          </ul>
-        </nav>
-        {% endif %}
-      </aside>
+      {% set sideNavSections = [] %}
+      {% do sideNavSections.append({
+        "id": "view-the-data",
+        "heading": "View the data",
+        "hint": "You can explore this data",
+        "links": (
+          [{"text": "On a map", "href": "/map?dataset=" ~ dataset["dataset"]}] if dataset['typology'] == 'geography' else []
+        ) + [
+          {"text": "As a list", "href": "/entity?dataset=" ~ dataset["dataset"]}
+        ]
+      }) %}
+      {% do sideNavSections.append({
+        "id": "download-the-data",
+        "heading": "Download the data",
+        "hint": "You can take a copy of this data as",
+        "links": [
+          {"text": "CSV", "href": data_file_url ~ "/dataset/" ~ dataset["dataset"] ~ ".csv", "visuallyHiddenPrefix": "Download this data as "},
+          {"text": "JSON", "href": data_file_url ~ "/dataset/" ~ dataset["dataset"] ~ ".json", "visuallyHiddenPrefix": "Download this data as "}
+        ] + (
+          [
+            {"text": "GeoJSON", "href": data_file_url ~ "/dataset/" ~ dataset["dataset"] ~ ".geojson", "visuallyHiddenPrefix": "Download this data as "},
+            {"text": "Parquet", "href": data_file_url ~ "/dataset/" ~ dataset["dataset"] ~ ".parquet", "visuallyHiddenPrefix": "Download this data as "}
+          ] if dataset['typology'] == 'geography' else []
+        )
+      }) %}
+      {% do sideNavSections.append({
+        "id": "specification",
+        "heading": "Dataset definition",
+        "hint": "You can view the definition of this dataset including the list of fields",
+        "links": [
+          {"text": "Dataset definition for " ~ dataset["name"] ~ " dataset", "href": "https://digital-land.github.io/specification/dataset/" ~ dataset["dataset"]}
+        ]
+      }) %}
+      {% if dataset['consideration'] %}
+        {% do sideNavSections.append({
+          "id": "data-design",
+          "heading": "Designing the data",
+          "hint": "You can see details about how this dataset has been designed for planning.data.gov.uk",
+          "links": [
+            {"text": dataset['consideration'] ~ " planning consideration", "href": "https://design.planning.data.gov.uk/planning-consideration/" ~ dataset['consideration']}
+          ]
+        }) %}
+      {% endif %}
+      {{ appSideNav({ "sections": sideNavSections }) }}
     </div>
   </div>
 

--- a/application/templates/entity.html
+++ b/application/templates/entity.html
@@ -2,6 +2,7 @@
 {% set templateName = "dl-info/entity.html" %}
 
 {%- from "govuk_frontend_jinja/components/tabs/macro.html" import govukTabs %}
+{%- from "govuk_frontend_jinja/components/table/macro.html" import govukTable %}
 {%- from "components/map/macro.jinja" import map %}
 {%- from "components/summary-card/macro.jinja" import appSummaryCard %}
 {%- from "components/entity-value/macro.jinja" import entityValue %}
@@ -76,57 +77,67 @@
     </div>
 
     <div class="govuk-grid-column-three-quarters">
-      {% call appSummaryCard({ 'classes': 'govuk-!-margin-bottom-0' }) %}
-        <table class="govuk-table">
-          <thead class="govuk-table__head">
-            <tr class="govuk-table_row">
-              <th scope="col" class="govuk-table__header">Field</th>
-              <th scope="col" class="govuk-table__header">Value</th>
-              <th scope="col" class="govuk-table__header"><span class='govuk-visually-hidden'>Fact links</span></th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            {% for field in row.keys() %}
-              {% if field is not in ['entity','organisation-entity'] %}
-              {%- if field not in ["geometry","point","organisation-entity","json"] or row[field] is not none  %}
-              <tr class="govuk-table__row">
-                <th scope="row" class="app-table__header app-table__header--row">
-                  {{ entityField(field, fields, dataset_fields) }}
-                </th>
-                <td class="govuk-table__cell app-table__cell">
-                  {% if field == 'geometry' %}
-                    <code class ="app-code-block" id="geometry-content">
-                      {% if row[field] is not none %}
-                        {{ row[field][:100000] }}{% if row[field]|length > 100000 %}... <a href="javascript:void(0);" onclick="expandGeometry()">Load More</a>{% endif %}
-                      {% endif %}
-                      </code>
-                    <code class ="app-code-block" id="geometry-full-content" style="display: none;">
-                      {{ row[field] }}
-                    </code>
-                  {% else %}
-                    {{ entityValue(field, row[field], fields, dataset_fields, organisation_entity, linked_entities, dataset) }}
+      {% call appSummaryCard({ 'classes': 'govuk-!-margin-bottom-0', 'titleText': 'About this entity' }) %}
+        {% set rows = [] %}
+        {% for field in row.keys() %}
+          {% if field is not in ['entity','organisation-entity'] %}
+          {%- if field not in ["geometry","point","organisation-entity","json"] or row[field] is not none  %}
+            {% set valueHtml %}
+              {% if field == 'geometry' %}
+                <code class ="app-code-block" id="geometry-content">
+                  {% if row[field] is not none %}
+                    {{ row[field][:100000] }}{% if row[field]|length > 100000 %}... <a href="javascript:void(0);" onclick="expandGeometry()">Load More</a>{% endif %}
                   {% endif %}
-                </td>
-                {% if field not in ['curie', 'dataset', 'organisation-curie', 'typology', 'quality'] %}
-                  <td class="govuk-table__cell govuk-!-font-size-14 govuk-!-text-align-right">
-                    <a href="/fact?{{ {'dataset': row['dataset'], 'entity': row['entity'], 'field': field}|make_url_param_str }}" class="govuk-link">Facts</a>
-                  </td>
-                    {% else %}
-                      <td class="govuk-table__cell govuk-!-font-size-14 govuk-!-text-align-right"><span class='govuk-visually-hidden'>no fact link</span></td>
-                    {% endif %}
-                  </tr>
-                {%- endif %}
+                  </code>
+                <code class ="app-code-block" id="geometry-full-content" style="display: none;">
+                  {{ row[field] }}
+                </code>
+              {% else %}
+                {{ entityValue(field, row[field], fields, dataset_fields, organisation_entity, linked_entities, dataset) }}
               {% endif %}
-            {% endfor %}
-          </tbody>
-          <script>
-            function expandGeometry() {
-              document.getElementById('geometry-content').style.display = 'none';
-              document.getElementById('geometry-full-content').style.display = 'block';
-            }
-          </script>
+            {% endset %}
+            {% set factsHtml %}
+              {% if field not in ['curie', 'dataset', 'organisation-curie', 'typology', 'quality'] %}
+                <a href="/fact?{{ {'dataset': row['dataset'], 'entity': row['entity'], 'field': field}|make_url_param_str }}" class="govuk-link">Facts</a>
+              {% else %}
+                <span class='govuk-visually-hidden'>no fact link</span>
+              {% endif %}
+            {% endset %}
+            {% do rows.append([
+              {
+                'html': entityField(field, fields, dataset_fields)
+              },
+              {
+                'html': valueHtml,
+                'classes': 'app-table__cell'
+              },
+              {
+                'html': factsHtml,
+                'classes': 'govuk-!-font-size-14 govuk-!-text-align-right'
+              }
+            ]) %}
+          {%- endif %}
+          {% endif %}
+        {% endfor %}
 
-        </table>
+        {{
+          govukTable({
+            'firstCellIsHeader': true,
+            'head': [
+              {'html': '', 'classes': 'app-table__header--visually-hidden'},
+              {'html': '', 'classes': 'app-table__header--visually-hidden'},
+              {'html': "<span class='govuk-visually-hidden'>Fact links</span>", 'classes': 'app-table__header--visually-hidden'}
+            ],
+            'rows': rows
+          })
+        }}
+
+        <script>
+          function expandGeometry() {
+            document.getElementById('geometry-content').style.display = 'none';
+            document.getElementById('geometry-full-content').style.display = 'block';
+          }
+        </script>
       {% endcall %}
 
       {% set data_to_send = {

--- a/application/templates/entity.html
+++ b/application/templates/entity.html
@@ -8,6 +8,7 @@
 {%- from "components/entity-value/macro.jinja" import entityValue %}
 {%- from "components/entity-field/macro.jinja" import entityField %}
 {%- from "components/back-button/macro.jinja" import dlBackButton %}
+{%- from "components/side-nav/macro.jinja" import appSideNav %}
 
 {% set is_truncated = false %}
 {% if row['geometry'] %}
@@ -76,7 +77,7 @@
       <h1 class="govuk-heading-xl">{{ row_name }}</h1>
     </div>
 
-    <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-grid-column-two-thirds">
       {% block recordGeometry -%}
         {%- if includesMap %}
           {% call appSummaryCard({
@@ -230,8 +231,60 @@
 
     </div>
 
+    <div class="govuk-grid-column-one-third">
+      {% set sideNavSections = [] %}
+      {% if dataset and entity_lat is not none and entity_lng is not none %}
+        {% do sideNavSections.append({
+          "id": "view-the-data",
+          "heading": "View the data",
+          "hint": "You can explore this data",
+          "links": [
+            {"text": "On a map", "href": "/map?dataset=" ~ dataset.dataset ~ "#" ~ entity_lat ~ "," ~ entity_lng ~ ",15z"}
+          ]
+        }) %}
+      {% endif %}
+      {% do sideNavSections.append({
+        "id": "download-the-data",
+        "heading": "Download the data",
+        "hint": "You can take a copy of this data as",
+        "links": (
+          [
+            {"text": "JSON", "href": "/entity/" ~ row["entity"] ~ ".json", "visuallyHiddenPrefix": "Download this data as ",
+              "attributes": [{"key": "download", "value": row["entity"] ~ ".json"}]}
+          ]
+          + (
+            [
+              {"text": "GeoJSON", "href": "/entity/" ~ row["entity"] ~ ".geojson", "visuallyHiddenPrefix": "Download this data as ",
+                "attributes": [{"key": "download", "value": row["entity"] ~ ".geojson"}]}
+            ] if geometry_exists else []
+          )
+        )
+      }) %}
+      {% if dataset %}
+        {% do sideNavSections.append({
+          "id": "specification",
+          "heading": "Dataset definition",
+          "hint": "You can view the definition of this dataset including the list of fields",
+          "links": [
+            {"text": "Dataset definition for " ~ dataset.name ~ " dataset", "href": "https://digital-land.github.io/specification/dataset/" ~ dataset.dataset}
+          ]
+        }) %}
+      {% endif %}
+      {% if dataset.consideration %}
+        {% do sideNavSections.append({
+          "id": "data-design",
+          "heading": "Designing the data",
+          "hint": "You can see details about how this dataset has been designed for planning.data.gov.uk",
+          "links": [
+            {"text": dataset.consideration ~ " planning consideration", "href": "https://design.planning.data.gov.uk/planning-consideration/" ~ dataset.consideration}
+          ]
+        }) %}
+      {% endif %}
+      {{ appSideNav({ "sections": sideNavSections }) }}
+    </div>
+
     {% if local_plans['local-plan'] %}
-    <div class="govuk-grid-column-three-quarters govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6 govuk-!-margin-bottom-6">
       {% call appSummaryCard({
       'classes': 'govuk-!-margin-bottom-0',
       'titleText': 'Related Local Plans'
@@ -261,7 +314,7 @@
       {% endcall %}
     </div>
     {% elif entity.dataset == "local-plan-boundary" %}
-    <div class="govuk-grid-column-three-quarters govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6 govuk-!-margin-bottom-6">
       {% call appSummaryCard({
       'classes': 'govuk-!-margin-bottom-0',
       'titleText': 'Related Local Plans'
@@ -280,7 +333,7 @@
     {% endif %}
 
     {% if local_plans['local-plan-timetable'] %}
-      <div class="govuk-grid-column-three-quarters govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+      <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6 govuk-!-margin-bottom-6">
         {% call appSummaryCard({
             'classes': 'govuk-!-margin-bottom-0',
             'titleText': 'Related Local Plan Timetable'
@@ -309,7 +362,7 @@
   {% endif %}
 
     {% if local_plans['local-plan-document'] %}
-    <div class="govuk-grid-column-three-quarters govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6 govuk-!-margin-bottom-6">
       {% call appSummaryCard({
       'classes': 'govuk-!-margin-bottom-0',
       'titleText': 'Related Local Plan Document'

--- a/application/templates/entity.html
+++ b/application/templates/entity.html
@@ -77,6 +77,26 @@
     </div>
 
     <div class="govuk-grid-column-three-quarters">
+      {% block recordGeometry -%}
+        {%- if includesMap %}
+          {% call appSummaryCard({
+            'classes': 'govuk-!-margin-bottom-6',
+            'titleText': 'Local Plan Boundary' if pipeline_name == 'local-plan' else 'Geographical area',
+          })%}
+
+            {{
+              map({
+                "mapId": "map",
+                'height': 320,
+                'enableZoomControls': true,
+                'geojsons': [geojson_data|get_entity_geometry],
+                'paint_options': dataset.paint_options,
+              })
+            }}
+              {% endcall %}
+        {%- endif %}
+      {%- endblock recordGeometry %}
+
       {% call appSummaryCard({ 'classes': 'govuk-!-margin-bottom-0', 'titleText': 'About this entity' }) %}
         {% set rows = [] %}
         {% for field in row.keys() %}
@@ -321,49 +341,6 @@
       {% endcall %}
     </div>
     {% endif %}
-    <div class="govuk-grid-column-full govuk-!-margin-top-6"></div>
-
-    <div class="govuk-grid-column-full">
-    {% block recordGeometry -%}
-      {%- if includesMap %}
-        {% call appSummaryCard({
-          'classes': 'govuk-!-margin-bottom-0',
-          'titleText': 'Local Plan Boundary' if pipeline_name == 'local-plan' else 'Geographical area',
-          'actions': {
-            'items': [
-              {
-                'text': 'Download geojson',
-                'href': (
-                '/entity/' +
-                (geojson_data["entity"] if pipeline_name == 'local-plan' else row["entity"]) | string +
-                '.geojson'
-              ),
-                'attributes': [
-                  {
-                    'key': 'download',
-                    'value': (geojson_data["entity"] if pipeline_name == 'local-plan' else row["entity"])
-                      | string + '.geojson'
-                  }
-                ]
-              }
-            ],
-          }
-        })%}
-
-        {{
-          map({
-            "mapId": "map",
-            'height': 460,
-            'enableZoomControls': true,
-            'geojsons': [geojson_data|get_entity_geometry],
-            'paint_options': dataset.paint_options,
-          })
-        }}
-          {% endcall %}
-      {%- endif %}
-    {%- endblock recordGeometry %}
-    </div>
-
     {%- if history_enabled %}
       <div id="history">
         {#{%- block entryHistory %}#}

--- a/assets/stylesheets/component/_table.scss
+++ b/assets/stylesheets/component/_table.scss
@@ -2,6 +2,11 @@
   &__header {
     text-align: left;
     padding-right: 1em;
+
+    &--visually-hidden {
+      padding: 0;
+      border: 0;
+    }
   }
   &__header--row {
     font-weight: normal;

--- a/tests/integration/test_entity.py
+++ b/tests/integration/test_entity.py
@@ -40,6 +40,92 @@ def test_entity_page_shows_organisation_name_not_none(
     assert org_link.get_text(strip=True) == "Dacorum Borough Council"
 
 
+def test_entity_page_side_nav_for_geography_entity(
+    client, db_session, test_data, exclude_middleware
+):
+    """
+    Assert that the side navigation renders all sections and links for a
+    geography entity.
+
+    Entity 1 (dataset "greenspace", typology "geography") has both geometry
+    and a point in the test data, and the "greenspace" dataset has a
+    "consideration" set - so all four side-nav sections should render.
+    """
+    response = client.get("/entity/1", follow_redirects=True)
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    json_link = soup.find("a", href="/entity/1.json")
+    assert json_link is not None, "JSON download link not found"
+    assert json_link.get("download") == "1.json"
+
+    geojson_link = soup.find("a", href="/entity/1.geojson")
+    assert geojson_link is not None, "GeoJSON download link not found"
+    assert geojson_link.get("download") == "1.geojson"
+
+    map_link = soup.find(
+        "a",
+        href=lambda h: h
+        and h.startswith("/map?dataset=greenspace#")
+        and h.endswith(",15z"),
+    )
+    assert map_link is not None, "On a map link not found or malformed"
+
+    definition_link = soup.find(
+        "a", href="https://digital-land.github.io/specification/dataset/greenspace"
+    )
+    assert definition_link is not None, "Dataset definition link not found"
+
+    design_link = soup.find(
+        "a",
+        href="https://design.planning.data.gov.uk/planning-consideration/greenspace",
+    )
+    assert design_link is not None, "Designing the data link not found"
+
+
+def test_entity_page_side_nav_for_non_geography_entity(
+    client, db_session, test_data, exclude_middleware
+):
+    """
+    Assert that the side navigation omits the map and GeoJSON links for an
+    entity with no geometry, and separately omits "Designing the data" for
+    a dataset with no consideration set.
+
+    Entity 101 (dataset "local-authority", typology "organisation") has no
+    geometry/point, so the map link and GeoJSON download should be absent.
+    Separately - and unrelated to geometry or typology - the
+    "local-authority" dataset has no "consideration" set, so "Designing
+    the data" should also be absent. JSON download and "Dataset
+    definition" should still be present either way.
+    """
+    response = client.get("/entity/101", follow_redirects=True)
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    json_link = soup.find("a", href="/entity/101.json")
+    assert json_link is not None, "JSON download link not found"
+
+    geojson_link = soup.find("a", href="/entity/101.geojson")
+    assert geojson_link is None, "GeoJSON download link should not be shown"
+
+    map_link = soup.find(
+        "a", href=lambda h: h and h.startswith("/map?dataset=local-authority#")
+    )
+    assert map_link is None, "On a map link should not be shown"
+
+    definition_link = soup.find(
+        "a",
+        href="https://digital-land.github.io/specification/dataset/local-authority",
+    )
+    assert definition_link is not None, "Dataset definition link not found"
+
+    assert (
+        soup.find(id="data-design") is None
+    ), "Designing the data section should be absent"
+
+
 def test_fetch_linked_local_plans(db_session):
     lp_entity = {
         "entity": 4220006,

--- a/tests/unit/routers/test_entity.py
+++ b/tests/unit/routers/test_entity.py
@@ -9,6 +9,7 @@ from application.routers.entity import (
     _get_entity_json,
     _get_geojson,
     get_entity,
+    get_entity_lat_lng,
     search_entities,
 )
 
@@ -82,6 +83,27 @@ def multiple_entity_models():
     )
 
     return [model_1, model_2]
+
+
+def test_get_entity_lat_lng_parses_wkt():
+    entity = MagicMock()
+    entity.point = "POINT (-1.456 52.123)"
+    lat, lng = get_entity_lat_lng(entity)
+    assert lat == pytest.approx(52.123)
+    assert lng == pytest.approx(-1.456)
+
+
+def test_get_entity_lat_lng_returns_none_when_point_missing():
+    entity = MagicMock()
+    entity.point = None
+    assert get_entity_lat_lng(entity) == (None, None)
+
+
+def test_get_entity_lat_lng_returns_none_on_unparseable_wkt():
+    entity = MagicMock()
+    entity.entity = 123
+    entity.point = "not a valid wkt string"
+    assert get_entity_lat_lng(entity) == (None, None)
 
 
 def test__get_geojson_multiple_entity_models_provided(multiple_entity_models):


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This work is to improve the UI of the Entity page, re-using the side menu from the dataset page, separating the page into columns, moving the map, and migrating the table to the the official gov table component. 

There are 3 main parts to this ticket:

### Add side navigation to the entity page

The Dataset page has a side navigation which allows the user to easily
access links to download files of the dataset data. The Entity page does
not currently have this. We want the user to have easy access to
downloadable files and a consistent UI.

This change adds a side menu to the Entity page. Unlike on the Dataset
page The download links return a response from our API where the file
downloads reside as physical files on a separate service, here we return
a response from the API and force a file download via the HTML download
attribute. As such, it will only offer Json and GeoJson formats. This
behaviour is the same as what was already in place with a link on the
map for GeoJson.

The map link in the side-nav uses lat,lng coords to link to the map
page. To facilitate the use of the side-nav on both pages I have created
a shared side-nav macro template, now used by both the Dataset and
Entity pages.

Changes:
- Create Side nav template
- Refactor Dataset page to use template
- Apply template to Entity page
- Add tests

### Move entity page map to the top

Reposition the geographical-area map card from the bottom of the page
to the top of the main content column, ahead of the record table, so
it's visible without scrolling. The map now sits in the left column,
does not consume the full width of the page, and as such, the height has
also being reduced, cleaning up the UI. The new side-navigation that is
being introduced in a separate commit will contain a link to the
dedicated map page containing a full size map.

Because we are adding a side-nav to this page that will include data
download links, we no longer require the link on the embedded map, so
this is being removed.

Changes:
- Move map to top of page in left hand column
- Remove GeoJson download link from map

### Migrate entity record table to the shared govukTable component

The data HTML tables on the Dataset and Entity pages differ both
visually and in code despite serving largely the same purpose. The
Dataset page makes use of the official GovUk Table component. This
change replaces our own table markup and instead imports the GovUk
table. Because we do have an additional column for facts links, I
have preserved a hidden header row to allow screenreaders to read the
heading for the facts column, hence the additional CSS.

The first column is scoped to row, which declares this column as row
headings, as per a recent Accessibility audit (previously on the Dataset
page we just used bold text instead of proper headings, failing WCAG 2.2
requirements).

Changes:
- Refactor Entity page to use GovUk table component

_Note: There are ongoing conversations around tracking. We currently track download links with a broad brush by targeting any link with a documented file extension and then record a `file_download` to the GA dataLayer. This provides some rudimentary information but there are some challenges in distinguishing between file downloads and API requests. The implementation here effectively wraps API requests into file downloads (which was existing behaviour via the GeoJson download on the map). Discussions are ongoing around how to best approach these issues in regards to tracking, where we can follow up on improvements._ 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/686

## QA Instructions, Screenshots, Recordings

| Before | After |
|--------|--------|
| <img width="1094" height="1302" alt="Screenshot 2026-07-31 at 11 47 09" src="https://github.com/user-attachments/assets/95b5528b-4f42-4e59-b9a2-99783ecbf9f1" /> | <img width="1204" height="1313" alt="Screenshot 2026-07-31 at 11 19 33" src="https://github.com/user-attachments/assets/b1d1cd79-5ea8-430c-a1c1-4c360989fbad" /> |
| <img width="1092" height="1322" alt="Screenshot 2026-07-31 at 11 46 01" src="https://github.com/user-attachments/assets/6b944ea8-f85d-48a1-8e1f-8a6859414894" /> | <img width="1067" height="1315" alt="Screenshot 2026-07-31 at 11 19 50" src="https://github.com/user-attachments/assets/329d247d-a326-48d3-a491-85851ae65337" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced consistent, dynamic side navigation on dataset and entity pages, with contextual map, download, dataset definition, and “Designing the data” links.
  - Entity pages now show a clearer two-column layout and improved map/geometry placement, with link visibility driven by available location data.
- **Accessibility**
  - Improved table header rendering to better support screen readers (visually hidden header variant).
- **Bug Fixes**
  - More reliable location handling when an entity’s point data is missing or invalid, preventing broken map/download links.
- **Tests**
  - Added integration and unit coverage for side navigation and location parsing/link visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->