### PR TITLE
Fix Pip and Pip tools versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ server: export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 endif
 
 init::
-	python -m pip install --upgrade pip
-	python -m pip install pip-tools
+	# Pinned pip version because stdlib_pkgs no longer works since the update to 26.2, breaking the pipeline
+	python -m pip install --upgrade "pip==26.1.2" "pip-tools==7.6.0"
 	python -m piptools sync requirements/requirements.txt requirements/dev-requirements.txt --pip-args "--no-cache-dir"
 	python -m pre_commit install
 	npm install


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Pip 26.2 was released yesterday. This version removed private stdlib_pkgs symbol that pip-tools' sync command depends on, breaking our pipeline. This change fixes Pip and pip tools to the last known working versions. It does of course come with a maintenance burden; In future we can revert to using the latest stable version once this issue has been patched, or we no longer require the failing tools.

Changes:
- Fix Pip and pip tools verion in Makefile

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

No ticket

## QA Instructions, Screenshots, Recordings

<img width="1381" height="294" alt="Screenshot 2026-07-30 at 09 37 51" src="https://github.com/user-attachments/assets/4ec9a68e-2b8e-44db-81f6-66c2ea924f57" />

<img width="1014" height="620" alt="Screenshot 2026-07-30 at 09 50 03" src="https://github.com/user-attachments/assets/cd3272d8-d583-48df-87b6-2dda2770a99b" />

<img width="374" height="265" alt="Screenshot 2026-07-30 at 09 50 33" src="https://github.com/user-attachments/assets/9f2a1eae-7adf-46ba-95f9-54b11a996323" />



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: Dependency update only
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment setup to install consistent, pinned versions of pip and pip-tools.
  * Combined pip and pip-tools installation into a single setup step for more reliable initialisation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->