### PR TITLE
WCAG 2.2 Accessibility - Visible label does not match accessible name for input field

### DIFF
--- a/application/templates/components/filter-checkboxes/macro.jinja
+++ b/application/templates/components/filter-checkboxes/macro.jinja
@@ -10,7 +10,7 @@
 <div class="govuk-checkboxes" data-module="filter-checkboxes">
   <div class="dl-filter-group__auto-filter" id="input-container-{{ params.uniqueID }}" style="display: none;">
     <label for="input-{{ params.uniqueID }}" class="govuk-label govuk-visually-hidden">
-    Filter Show only
+    {{ params.filterLabel | default("Search") }}
     </label>
     <input id="input-{{ params.uniqueID }}" class="govuk-input dl-filter-group__auto-filter__input" type="text" aria-describedby="checkbox-filter-{{ params.uniqueID }}" aria-controls="checkboxes-{{ params.uniqueID }}">
   </div>

--- a/application/templates/dataset_index.html
+++ b/application/templates/dataset_index.html
@@ -38,8 +38,7 @@
 	<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible" role='presentation'>
 
 	<form class="dl-filter-organisations-list__form filter-organisations-list__form--active govuk-!-margin-bottom-9" data-module="dl-list-filter-form">
-		<label class="dl-list-filter__label govuk-label govuk-!-font-weight-bold" for="filter-organisations-list" aria-hidden="true">I'm looking for</label>
-		<label class="govuk-visually-hidden" for="filter-organisations-list">Dataset filter</label>
+		<label class="dl-list-filter__label govuk-label govuk-!-font-weight-bold" for="filter-organisations-list">I'm looking for</label>
 		<input class="dl-list-filter__input govuk-input" type="text" id="filter-organisations-list" placeholder="enter dataset name, i.e. Ramsar site">
 	</form>
 

--- a/application/templates/partials/fact-search-facets.html
+++ b/application/templates/partials/fact-search-facets.html
@@ -28,7 +28,8 @@
     }) %}
     {{ dlFilterCheckboxes({
       "uniqueID": random_int(5),
-      "checkboxesHTML": checkboxesHTML
+      "checkboxesHTML": checkboxesHTML,
+      "filterLabel": "Search fields"
     }) }}
     {% endcall %}
   </div>

--- a/application/templates/partials/search-facets.html
+++ b/application/templates/partials/search-facets.html
@@ -46,7 +46,8 @@
     }) %}
     {{ dlFilterCheckboxes({
       "uniqueID": random_int(5),
-      "checkboxesHTML": checkboxesHTML
+      "checkboxesHTML": checkboxesHTML,
+      "filterLabel": "Search datasets"
     }) }}
     {% endcall %}
   </div>
@@ -76,7 +77,8 @@
     }) %}
     {{ dlFilterCheckboxes({
       "uniqueID": random_int(5),
-      "checkboxesHTML": checkboxesHTML
+      "checkboxesHTML": checkboxesHTML,
+      "filterLabel": "Search locations"
     }) }}
     {% endcall %}
   </div>
@@ -122,7 +124,8 @@
         }) %}
         {{ dlFilterCheckboxes({
           "uniqueID": random_int(5),
-          "checkboxesHTML": checkboxesHTML
+          "checkboxesHTML": checkboxesHTML,
+          "filterLabel": "Search organisations"
         }) }}
       {% endcall %}
     </div>
@@ -151,7 +154,8 @@
     }) %}
       {{ dlFilterCheckboxes({
         "uniqueID": random_int(5),
-        "checkboxesHTML": checkboxesHTML
+        "checkboxesHTML": checkboxesHTML,
+        "filterLabel": "Search periods"
       }) }}
     {% endcall %}
   </div>

--- a/assets/javascripts/LayerControls.js
+++ b/assets/javascripts/LayerControls.js
@@ -125,7 +125,7 @@ export default class LayerControls {
       const filterLabel = document.createElement('label');
       filterLabel.setAttribute('for', 'input-71108');
       filterLabel.classList.add('govuk-label', 'govuk-visually-hidden');
-      filterLabel.textContent = 'Filter Show only';
+      filterLabel.textContent = 'Search data layers';
 
       this.$textbox = document.createElement('input');
       this.$textbox.setAttribute('id', 'input-71108');


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

#### Entity page filters:

In the filter menus on the Entity page.

Several filter sections, including Dataset, Location and others, contain
search inputs with the accessible label "Filter Show only", while users
are presented with a visible search icon.

This creates a mismatch between what users see and the accessible name
announced by assistive technologies. Voice control users may attempt to
interact with the control using commands such as "click search", but the
control is not exposed with that name.

This change updates labels to more closely resemble what is displayed on
screen, improving experience when using voice activation software.

Changes:
- Update visually hidden labels

#### Dataset page filter

Context:
The dataset filter input has a visible label of "I'm looking
for", but this label is hidden from assistive technologies using
  aria-hidden="true".

A second visually hidden label, "Dataset filter", is used as the
accessible name for the input.

As a result, the visible label does not match the accessible name
exposed to assistive technologies. This can cause issues for voice
activation users, who may attempt to interact with the field using the
visible text they see on screen.

Voice activation users may attempt to reference the input using commands
such as "click I'm looking for", but assistive technologies identify the
input using the name "Dataset filter".

When visible labels and accessible names do not match, users may
struggle to activate or interact with controls using speech recognition
software.

This can make it harder to search for datasets and navigate the datasets
page.

Changes:
- Remove aria-label so that the visible label is used, making the
  experience consistent for all users

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/715
- Closes https://github.com/digital-land/digital-land/issues/716

## QA Instructions, Screenshots, Recordings

| Before | After |
|--------|--------|
| <img width="1259" height="278" alt="Screenshot 2026-08-07 at 13 11 23" src="https://github.com/user-attachments/assets/ac8d8139-2b0e-4746-b012-be19d3917dd4" /> | <img width="1243" height="296" alt="Screenshot 2026-08-07 at 13 08 49" src="https://github.com/user-attachments/assets/8fc94846-7159-4e4b-8459-b8d7e8f6a516" /> |
| <img width="1028" height="132" alt="Screenshot 2026-08-07 at 14 28 01" src="https://github.com/user-attachments/assets/1416f5bf-01be-4e61-91d3-0dc682242d15" /> | <img width="792" height="119" alt="Screenshot 2026-08-07 at 14 30 30" src="https://github.com/user-attachments/assets/34f96a97-3731-42e0-9981-57c293cf91bf" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: A11y updates only
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved filter labels for assistive technologies.
  * Removed a redundant visually hidden dataset filter label.

* **Usability**
  * Replaced generic filter text with clearer, context-specific labels.
  * Added descriptive labels for search fields, datasets, locations, organisations, periods, and data layers.
  * Filter labels can now be customised, with “Search” used as the default when no label is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->