### PR TITLE
WCAG 2.2 - DAC Contrast Minimum - Feedback link fails minimum contrast ratio when focused

### DIFF
--- a/assets/stylesheets/component/hero/_phase-banner.scss
+++ b/assets/stylesheets/component/hero/_phase-banner.scss
@@ -1,6 +1,6 @@
 .app-phase-banner--inverse {
   border-bottom-color: $app-hero-border-colour;
-  .govuk-link,
+  .govuk-link:not(:focus),
   .govuk-phase-banner__content {
     color: $app-hero-colour;
   }


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

Feedback link fails minimum contrast ratio when focused

When the "feedback" link in the hero banner on the homepage receives keyboard focus, the text fails to meet the minimum colour contrast requirements defined by WCAG 2.2.

The white link text is displayed on a yellow focus background, resulting in a contrast ratio of approximately 3.8:1, which is below the required 4.5:1 minimum contrast ratio for normal-sized text.

This changes hover state link colour from white to black inline with other links in the app and following gov.uk styleguides.

Changes:
- change hover state of feedback link from white to black

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/727

## QA Instructions, Screenshots, Recordings

| Before | After |
|--------|--------|
| <img width="714" height="512" alt="Screenshot 2026-08-11 at 10 17 02" src="https://github.com/user-attachments/assets/2d5c21b5-5fb9-4eea-bb3b-761a81d877cf" /> | <img width="708" height="602" alt="Screenshot 2026-08-11 at 10 17 34" src="https://github.com/user-attachments/assets/af2ec4ca-d709-4231-b782-a8c06204100c" /> | 

<img width="390" height="537" alt="Screenshot 2026-08-11 at 11 18 35" src="https://github.com/user-attachments/assets/dd20050c-1ced-4aee-94bc-817ffa917db5" />



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: _CSS update only_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved styling for focused links in inverse phase banners, ensuring they display correctly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->