### PR TITLE
WCAG 2.2 - DAC Non descriptive labels 01

### DIFF
--- a/application/templates/partials/fact-search-facets.html
+++ b/application/templates/partials/fact-search-facets.html
@@ -35,7 +35,7 @@
 
   <div class="govuk-button-group">
     {{ govukButton({
-      "text": "Search"
+      "text": "Apply filters"
     }) }}
     <a href="{{ fact_search_form_url }}?{{ {'dataset': query_params['dataset'], 'entity': query_params['entity']}|make_url_param_str }}" class="govuk-link">Clear</a>
   </div>

--- a/application/templates/partials/search-facets.html
+++ b/application/templates/partials/search-facets.html
@@ -224,7 +224,7 @@
 
   <div class="govuk-button-group">
     {{ govukButton({
-      "text": "Search",
+      "text": "Apply filters",
       "type": "submit",
     }) }}
     <a href="{{ search_form_url }}" class="govuk-link">Clear</a>

--- a/tests/acceptance/pageObjectModels/searchPOM.py
+++ b/tests/acceptance/pageObjectModels/searchPOM.py
@@ -58,7 +58,7 @@ class SearchPOM:
 
     def search_button_click(self):
         with self.page.expect_navigation() as navigation_info:
-            self.page.get_by_role("button", name="Search").click()
+            self.page.get_by_role("button", name="Apply filters").click()
         assert navigation_info.value.ok
 
     def clear_filter(self, filter):

--- a/tests/acceptance/test_entity.py
+++ b/tests/acceptance/test_entity.py
@@ -108,7 +108,7 @@ def test_find_an_entity_via_the_search_page(
     # filter down to just get geographies
     page.get_by_role("heading", name="Typology").click()
     page.get_by_label("geography").check()
-    page.get_by_role("button", name="Search").click()
+    page.get_by_role("button", name="Apply filters").click()
 
     # check that only two results are returned
     assert page.get_by_role("heading", name="A space").count() == 1
@@ -117,7 +117,7 @@ def test_find_an_entity_via_the_search_page(
 
     # filter down to just get A space
     page.get_by_label("Greenspace").check()
-    page.get_by_role("button", name="Search").click()
+    page.get_by_role("button", name="Apply filters").click()
 
     # check that only A space is returned
     assert page.get_by_role("heading", name="A space").count() == 1

--- a/tests/acceptance/test_search.py
+++ b/tests/acceptance/test_search.py
@@ -27,7 +27,7 @@ def test_blank_search(server_url, page):
     page.click("text=Search")
 
     with page.expect_response("**/entity/**") as response:
-        page.click("button:has-text(' Search ')")
+        page.click("button:has-text('Apply filters')")
 
     assert response.value.ok
 
@@ -247,7 +247,7 @@ def test_search_second_submit_replaces_area_query_without_duplicate_q(server_url
     area_input.fill("SW1P 4DF")
 
     with page.expect_navigation() as navigation_info:
-        search_form.get_by_role("button", name="Search").click()
+        search_form.get_by_role("button", name="Apply filters").click()
     assert navigation_info.value.ok
 
     query_params = parse_qs(urlsplit(page.url).query)


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

The "Search" button below the filter section is not sufficiently descriptive for screen reader users.

When navigating the page using a screen reader's forms list or controls list, users may encounter the button without the surrounding filter context and be unable to determine what action the button performs.

Changes:
- Update filter text from "Search" to "Apply filters"

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/729

## QA Instructions, Screenshots, Recordings

| | Before | After |
|-|--------|--------|
| Entity page | <img width="359" height="395" alt="Screenshot 2026-08-11 at 13 41 52" src="https://github.com/user-attachments/assets/7d216e78-8613-42e1-9c40-40c67ea71fa1" /> | <img width="363" height="396" alt="Screenshot 2026-08-11 at 13 51 37" src="https://github.com/user-attachments/assets/734a6a56-a274-4aba-9ef9-7bd834357c5b" /> |
| Facts page | <img width="346" height="440" alt="Screenshot 2026-08-11 at 13 42 06" src="https://github.com/user-attachments/assets/67178e41-1244-4809-8ce8-133dd55fcda4" /> | <img width="341" height="443" alt="Screenshot 2026-08-11 at 13 51 14" src="https://github.com/user-attachments/assets/d5498858-4865-48bd-9b78-e180cd3d7863" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Renamed search and facet submission buttons from **“Search”** to **“Apply filters”** for clearer guidance when refining results.

- **Tests**
  - Updated acceptance coverage to reflect the new button label across search, entity, typology and dataset filtering workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->