### PR TITLE
WCAG 2.2. - DAC Menu 01 - Sub menu focus order incorrect (Update Data sub-nav to new accessible layout)

### DIFF
--- a/application/templates/components/header-bar/macro.jinja
+++ b/application/templates/components/header-bar/macro.jinja
@@ -2,12 +2,6 @@
 
 {% macro dlHeaderBar(params={}) %}
 {% set _navitems = params.get('items', []) %}
-{% set _subnav = [] %}
-{% for item in _navitems %}
-  {% if item.children %}
-    {% set _ = _subnav.extend(item.children) %}
-  {% endif %}
-{% endfor %}
 <header class="govuk-header dl-header{{ ' ' + params.classes if params.classes }}" role="banner" data-module="govuk-header">
   <div class="govuk-header__container {{ 'dl-container--full-width' if params.fullWidth else 'govuk-width-container' }}">
     <div class="govuk-header__logo">
@@ -40,7 +34,8 @@
           {% for item in _navitems %}
           <li class="govuk-service-navigation__item{% if item.children %} govuk-service-navigation__item--toggle{% endif %}" data-nav-href="{{ item.href }}">
             {% if item.children %}
-            <button type="button" class="govuk-service-navigation__link" id="dl-subnav-toggle" aria-expanded="false" aria-controls="dl-subnav">
+            {% set subnav_id = 'dl-subnav-' ~ (item.text | slugify) %}
+            <button type="button" class="govuk-service-navigation__link dl-subnav-toggle" aria-expanded="false" aria-controls="{{ subnav_id }}">
               {{ item.text }}
               <span class="dl-subnav-toggle__icon">
                 <svg width="10" height="10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -48,6 +43,17 @@
                 </svg>
               </span>
             </button>
+            <div class="dl-subnav" id="{{ subnav_id }}">
+              <nav aria-label="Data sub-menu">
+                <ul class="govuk-service-navigation__list">
+                  {% for child in item.children %}
+                  <li class="govuk-service-navigation__item" data-subnav-href="{{ child.href }}">
+                    <a class="govuk-service-navigation__link" href="{{ child.href }}">{{ child.text }}</a>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </nav>
+            </div>
             {% else %}
             <a class="govuk-service-navigation__link" href="{{ item.href }}">{{ item.text }}</a>
             {% endif %}
@@ -58,19 +64,6 @@
       {% endif %}
     </div>
   </div>
-  {% if _subnav | length > 0 %}
-  <div class="{{ 'dl-container--full-width' if params.fullWidth else 'govuk-width-container'}}" id="dl-subnav">
-    <nav aria-label="Data sub-menu" class="govuk-service-navigation__wrapper">
-      <ul class="govuk-service-navigation__list" id="sub-navigation-list">
-        {% for child in _subnav %}
-        <li class="govuk-service-navigation__item" data-subnav-href="{{ child.href }}">
-          <a class="govuk-service-navigation__link" href="{{ child.href }}">{{ child.text }}</a>
-        </li>
-        {% endfor %}
-      </ul>
-    </nav>
-  </div>
-  {% endif %}
 </section>
 <script>
   (function() {
@@ -88,29 +81,24 @@
       }
     });
 
-    var toggle = document.getElementById('dl-subnav-toggle');
-    var subnav = document.getElementById('dl-subnav');
+    var toggles = document.querySelectorAll('.dl-subnav-toggle');
+    toggles.forEach(function(toggle) {
+      var subnav = document.getElementById(toggle.getAttribute('aria-controls'));
+      if (!subnav) {
+        return;
+      }
 
-    if (toggle && subnav) {
       subnav.hidden = true;
 
-      // Set the selected sub-menu to `--active`
       var subnavItems = subnav.querySelectorAll('.govuk-service-navigation__item');
       subnavItems.forEach(function(item) {
         var href = item.getAttribute('data-subnav-href');
 
         if (href && pathname.startsWith(href)) {
           item.classList.add('govuk-service-navigation__item--active');
+          toggle.parentElement.classList.add('govuk-service-navigation__item--active');
         }
-
       });
-
-      // Make the sub-menu visible when the user is on a child page
-      if (pathname.startsWith('/dataset') || pathname.startsWith('/organisation') || pathname.startsWith('/local-plans')) {
-        toggle.setAttribute('aria-expanded', 'true');
-        subnav.hidden = false;
-        toggle.parentElement.classList.add("govuk-service-navigation__item--active")
-      }
 
       toggle.addEventListener('click', function() {
         var expanded = toggle.getAttribute('aria-expanded') === 'true';
@@ -122,7 +110,7 @@
           toggle.blur();
         }
       });
-    }
+    });
 
   })();
 </script>

--- a/assets/stylesheets/component/_header-bar.scss
+++ b/assets/stylesheets/component/_header-bar.scss
@@ -19,7 +19,7 @@
 // Style for menu "Data" button to match the other
 // menu `li > a` items
 .govuk-service-navigation__item--toggle {
-  #dl-subnav-toggle {
+  .dl-subnav-toggle {
     // Reset button styles
     background: none;
     border: none;
@@ -58,6 +58,52 @@
     // Arrow points down when expanded
     &[aria-expanded="true"] .dl-subnav-toggle__icon {
       transform: rotate(0deg);
+    }
+  }
+}
+
+.dl-subnav {
+  @include govuk-media-query($until: tablet) {
+    padding: govuk-spacing(3) 0 0 govuk-spacing(4);
+  }
+
+  @include govuk-media-query($from: tablet) {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 5;
+    min-width: 200px;
+    background-color: govuk-tint($govuk-brand-colour, 95%);
+    border: 1px solid $govuk-border-colour;
+    box-shadow: 0 4px 4px rgba(0, 0, 0, 0.15);
+    padding: govuk-spacing(3);
+
+    .govuk-service-navigation__list {
+      display: block;
+      margin: 0;
+    }
+
+    .govuk-service-navigation__item {
+      position: relative;
+      display: block;
+      margin: 0;
+      padding: govuk-spacing(2) 0;
+      border: 0;
+
+      &:not(:last-child) {
+        margin-right: 0;
+        border-bottom: 1px solid $govuk-border-colour;
+      }
+
+      &--active::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: -(govuk-spacing(3));
+        width: govuk-spacing(1);
+        background-color: govuk-shade($govuk-link-colour, 10%);
+      }
     }
   }
 }

--- a/tests/acceptance/test_acceptance.py
+++ b/tests/acceptance/test_acceptance.py
@@ -25,17 +25,17 @@ def test_acceptance(
     page.goto(server_url)
 
     # Assert Data -> Datasets page loads
-    page.locator("#dl-subnav-toggle").click()
-    page.locator("#dl-subnav").wait_for(state="visible")
-    page.locator("#dl-subnav >> text=Datasets").click()
+    page.locator(".dl-subnav-toggle").click()
+    page.locator(".dl-subnav").wait_for(state="visible")
+    page.locator(".dl-subnav >> text=Datasets").click()
     assert page.url == f"{server_url}/dataset/"
     assert page.text_content("h1") == "Datasets"
     page.goto(server_url)
 
     # Assert Data -> Organisations page loads
-    page.locator("#dl-subnav-toggle").click()
-    page.locator("#dl-subnav").wait_for(state="visible")
-    page.locator("#dl-subnav >> text=Organisations").click()
+    page.locator(".dl-subnav-toggle").click()
+    page.locator(".dl-subnav").wait_for(state="visible")
+    page.locator(".dl-subnav >> text=Organisations").click()
     assert page.url == f"{server_url}/organisation/"
     assert page.text_content("h1") == "Organisations"
     page.goto(server_url)

--- a/tests/accessibility/test_navigation_accessibility.py
+++ b/tests/accessibility/test_navigation_accessibility.py
@@ -1,0 +1,20 @@
+def test_primary_navigation_subnav_focus_order(server_url, page):
+    """
+    Expanding a primary nav item's sub-nav inserts it into the tab
+    sequence immediately after the toggle, so the next tab stop is
+    inside the sub-menu, not the next primary nav item.
+    """
+    page.goto(server_url)
+
+    nav_with_subnav = page.locator(".govuk-service-navigation__item").filter(
+        has=page.get_by_role("button", name="Data", exact=True)
+    )
+    toggle = nav_with_subnav.get_by_role("button", name="Data", exact=True)
+    subnav = nav_with_subnav.locator(".dl-subnav")
+
+    toggle.focus()
+    page.keyboard.press("Enter")
+    assert toggle.get_attribute("aria-expanded") == "true"
+
+    page.keyboard.press("Tab")
+    assert subnav.locator(":focus").count() == 1


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

**Update Data sub-nav to new accessible layout**

This change presents a completely new layout for the sub-navigation items under "Data" in the primary navidation.

Previously, the sub-navigation was just added on to the end of the primary service navigation and toggled into view when Data was selected in the primary nav. This meant that the sub-navigation was separated from the parent item in the DOM, which consequently meant that tabbing throught items via the keyboard would not traverse naturaly from parent to child navigation items; instead the child items would only be reached after tabbing through every item in the primary navigation. This issue was also visually evident in the mobile view, where the child items would expand into display not under the parent, but underneath the whole menu at the bottom.

To address this, we have structured the DOM so that the children are correctly located with parent/child relationship. this has influenced design, and we have decided on a small overlay for the sub-navigation items, which is a change from the previous full page width display of the extended inline service navigation.


There is also some refactoring to the toggle javascript, using classes and dynamic IDs, which safeguards against regression if new sub-navs are introduced in future. It also shouldn't dictate our CSS, where we're now using classes which is better practice for specificity.

**Also adds accessibility test for primary navigation**

We currently only have one single file of generic accessibility tests, which runs playwright tests per page. If we were to add custom tests to that file for each feature it could grow beyond a scope that is
reasonable. This change introduces a new file with custom test for the navigation. Naming convention is intended to follow that of acceptance tests so we maintain familiar patterns: `test_[page]_accessibility`

The particular test in question here asserts that focus order naturally traverses through the sub-nav when opened from the primary navigation.

**Changes:**
- Update Data sub-nav to display in overlay
- Add accessibility test for focus order of sub-nav in primary nav


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/718

## QA Instructions, Screenshots, Recordings

| Before | After |
|--------|--------|
| <img width="1059" height="613" alt="Screenshot 2026-08-14 at 11 42 38" src="https://github.com/user-attachments/assets/31d8ccc9-3901-49f9-973f-ae0780d2abd2" /> | <img width="1049" height="557" alt="Screenshot 2026-08-14 at 11 43 16" src="https://github.com/user-attachments/assets/225f43c9-3122-4f4f-9726-c5666ef57ac1" /> |
| <img width="521" height="699" alt="Screenshot 2026-08-14 at 11 44 43" src="https://github.com/user-attachments/assets/9e31d0c8-9a8b-4297-b242-7df45e3987a8" /> | <img width="528" height="692" alt="Screenshot 2026-08-14 at 11 46 31" src="https://github.com/user-attachments/assets/e4cba521-03ef-4577-9020-003ba8d44aa2" /> | 
| <img width="526" height="473" alt="Screenshot 2026-08-14 at 11 50 51" src="https://github.com/user-attachments/assets/d23572b9-8e2b-4eeb-b036-9f11aaa1da65" /> | <img width="526" height="371" alt="Screenshot 2026-08-14 at 11 50 39" src="https://github.com/user-attachments/assets/748ab284-2c61-4aaa-8d92-22da97e2825d" /> |

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: _covered by existing tests_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved navigation menus so each sub-navigation appears beneath its relevant navigation item.
  * Added responsive dropdown styling with improved spacing, positioning, borders and shadows.
* **Accessibility**
  * Improved keyboard navigation by moving focus into expanded sub-navigation menus.
  * Added clearer expanded-state feedback for navigation controls.
* **Tests**
  * Added coverage for keyboard focus and expanded navigation states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->