### PR TITLE
Entity Search DB optimisation

### DIFF
--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -169,10 +169,7 @@ def _apply_field_filters(query, params, extension: Optional[SuffixEntity] = None
 
     if not include_fields and not exclude_fields:
         if extension and extension == SuffixEntity.json:
-            # Selecting EntityOrm itself also selects the _geometry_geojson and
-            # _point_geojson column properties, so every geometry crosses the
-            # wire twice - once as EWKB and again as GeoJSON text. The json
-            # response always drops geojson, so select the table columns only.
+            # json response always drops geojson, so select the table columns only.
             return query.with_entities(*EntityOrm.__table__.columns)
         # HTML responses render the geojson, so leave the query alone.
         return query
@@ -289,42 +286,30 @@ def _apply_date_filters(query, params):
     return query
 
 
-ALL_SIMPLE_DATASETS = None
-
-
-def _split_requested_datasets(params):
+def _dataset_filters(params, subdivided_alias):
     """
-    Work out which datasets each branch of the spatial subqueries has to look at.
+    Build the dataset restriction for each branch of the spatial subqueries.
 
-    The outer query already filters on the requested dataset(s), but unless the
-    same restriction is pushed into the spatial subqueries they match geometries
-    across every dataset and the outer query then discards nearly all of them.
-
-    Returns (subdivided_datasets, simple_datasets). An empty list means that
-    branch cannot contribute any rows and can be skipped entirely.
-    simple_datasets is ALL_SIMPLE_DATASETS when no dataset filter was requested.
+    Returns (subdivided_filter, entity_filter). Either may be None, meaning that
+    branch cannot contribute any rows and should be skipped entirely.
     """
     requested = params.get("dataset") or []
     if not requested:
-        return complex_datasets, ALL_SIMPLE_DATASETS
+        # No dataset filter, so both branches keep their original scope.
+        return (
+            subdivided_alias.dataset.in_(complex_datasets),
+            EntityOrm.dataset.notin_(complex_datasets),
+        )
+
+    complex_requested = [d for d in requested if d in complex_datasets]
+    simple_requested = [d for d in requested if d not in complex_datasets]
     return (
-        [dataset for dataset in requested if dataset in complex_datasets],
-        [dataset for dataset in requested if dataset not in complex_datasets],
+        subdivided_alias.dataset.in_(complex_requested) if complex_requested else None,
+        EntityOrm.dataset.in_(simple_requested) if simple_requested else None,
     )
 
 
-def _searches_simple_datasets(simple_datasets):
-    return simple_datasets is ALL_SIMPLE_DATASETS or bool(simple_datasets)
-
-
-def _entity_dataset_filter(simple_datasets):
-    if simple_datasets is ALL_SIMPLE_DATASETS:
-        return EntityOrm.dataset.notin_(complex_datasets)
-    return EntityOrm.dataset.in_(simple_datasets)
-
-
 def _union_of(branches):
-    """UNION ALL the branches, avoiding a pointless wrapper for a single one."""
     if len(branches) == 1:
         return branches[0]
     return union_all(*branches)
@@ -333,16 +318,16 @@ def _union_of(branches):
 def _apply_location_filters(session, query, params):
     point = get_point(params)
     entity_subdivided_alias = aliased(EntitySubdividedOrm)
-    subdivided_datasets, simple_datasets = _split_requested_datasets(params)
+    subdivided_filter, entity_filter = _dataset_filters(params, entity_subdivided_alias)
 
     if point is not None:
         branches = []
 
         # Pre-filter EntitySubdividedOrm table
-        if subdivided_datasets:
+        if subdivided_filter is not None:
             branches.append(
                 select(entity_subdivided_alias.entity).where(
-                    entity_subdivided_alias.dataset.in_(subdivided_datasets),
+                    subdivided_filter,
                     entity_subdivided_alias.geometry_subdivided.isnot(None),
                     func.ST_IsValid(entity_subdivided_alias.geometry_subdivided),
                     func.ST_Contains(
@@ -353,10 +338,10 @@ def _apply_location_filters(session, query, params):
             )
 
         #  Pre-filter EntityOrm table
-        if _searches_simple_datasets(simple_datasets):
+        if entity_filter is not None:
             branches.append(
                 select(EntityOrm.entity).where(
-                    _entity_dataset_filter(simple_datasets),
+                    entity_filter,
                     EntityOrm.geometry.isnot(None),
                     func.ST_IsValid(EntityOrm.geometry),
                     func.ST_Contains(
@@ -381,10 +366,10 @@ def _apply_location_filters(session, query, params):
         branches = []
 
         # Entities from entity_subdivided (for complex datasets)
-        if subdivided_datasets:
+        if subdivided_filter is not None:
             branches.append(
                 select(entity_subdivided_alias.entity).where(
-                    entity_subdivided_alias.dataset.in_(subdivided_datasets),
+                    subdivided_filter,
                     entity_subdivided_alias.geometry_subdivided.isnot(None),
                     func.ST_IsValid(entity_subdivided_alias.geometry_subdivided),
                     spatial_function(entity_subdivided_alias.geometry_subdivided, geom),
@@ -392,10 +377,10 @@ def _apply_location_filters(session, query, params):
             )
 
         # Entities from EntityOrm (for all other datasets)
-        if _searches_simple_datasets(simple_datasets):
+        if entity_filter is not None:
             branches.append(
                 select(EntityOrm.entity).where(
-                    _entity_dataset_filter(simple_datasets),
+                    entity_filter,
                     or_(
                         and_(
                             EntityOrm.geometry.is_not(None),

--- a/application/data_access/entity_queries.py
+++ b/application/data_access/entity_queries.py
@@ -164,9 +164,17 @@ def _apply_field_filters(query, params, extension: Optional[SuffixEntity] = None
     include_fields = params.get("field", [])
     exclude_fields = params.get("exclude_field", [])
     # disable field filters if geojson as we already need to get them all
-    if (not include_fields and not exclude_fields) or (
-        extension and extension == SuffixEntity.geojson
-    ):
+    if extension and extension == SuffixEntity.geojson:
+        return query
+
+    if not include_fields and not exclude_fields:
+        if extension and extension == SuffixEntity.json:
+            # Selecting EntityOrm itself also selects the _geometry_geojson and
+            # _point_geojson column properties, so every geometry crosses the
+            # wire twice - once as EWKB and again as GeoJSON text. The json
+            # response always drops geojson, so select the table columns only.
+            return query.with_entities(*EntityOrm.__table__.columns)
+        # HTML responses render the geojson, so leave the query alone.
         return query
 
     # if requested specific fields only request those from db:
@@ -281,31 +289,84 @@ def _apply_date_filters(query, params):
     return query
 
 
+ALL_SIMPLE_DATASETS = None
+
+
+def _split_requested_datasets(params):
+    """
+    Work out which datasets each branch of the spatial subqueries has to look at.
+
+    The outer query already filters on the requested dataset(s), but unless the
+    same restriction is pushed into the spatial subqueries they match geometries
+    across every dataset and the outer query then discards nearly all of them.
+
+    Returns (subdivided_datasets, simple_datasets). An empty list means that
+    branch cannot contribute any rows and can be skipped entirely.
+    simple_datasets is ALL_SIMPLE_DATASETS when no dataset filter was requested.
+    """
+    requested = params.get("dataset") or []
+    if not requested:
+        return complex_datasets, ALL_SIMPLE_DATASETS
+    return (
+        [dataset for dataset in requested if dataset in complex_datasets],
+        [dataset for dataset in requested if dataset not in complex_datasets],
+    )
+
+
+def _searches_simple_datasets(simple_datasets):
+    return simple_datasets is ALL_SIMPLE_DATASETS or bool(simple_datasets)
+
+
+def _entity_dataset_filter(simple_datasets):
+    if simple_datasets is ALL_SIMPLE_DATASETS:
+        return EntityOrm.dataset.notin_(complex_datasets)
+    return EntityOrm.dataset.in_(simple_datasets)
+
+
+def _union_of(branches):
+    """UNION ALL the branches, avoiding a pointless wrapper for a single one."""
+    if len(branches) == 1:
+        return branches[0]
+    return union_all(*branches)
+
+
 def _apply_location_filters(session, query, params):
     point = get_point(params)
     entity_subdivided_alias = aliased(EntitySubdividedOrm)
+    subdivided_datasets, simple_datasets = _split_requested_datasets(params)
+
     if point is not None:
+        branches = []
+
         # Pre-filter EntitySubdividedOrm table
-        subdivided_ids_query = select(entity_subdivided_alias.entity).where(
-            entity_subdivided_alias.dataset.in_(complex_datasets),
-            entity_subdivided_alias.geometry_subdivided.isnot(None),
-            func.ST_IsValid(entity_subdivided_alias.geometry_subdivided),
-            func.ST_Contains(
-                entity_subdivided_alias.geometry_subdivided,
-                func.ST_GeomFromText(point, 4326),
-            ),
-        )
+        if subdivided_datasets:
+            branches.append(
+                select(entity_subdivided_alias.entity).where(
+                    entity_subdivided_alias.dataset.in_(subdivided_datasets),
+                    entity_subdivided_alias.geometry_subdivided.isnot(None),
+                    func.ST_IsValid(entity_subdivided_alias.geometry_subdivided),
+                    func.ST_Contains(
+                        entity_subdivided_alias.geometry_subdivided,
+                        func.ST_GeomFromText(point, 4326),
+                    ),
+                )
+            )
 
         #  Pre-filter EntityOrm table
-        entity_ids_query = select(EntityOrm.entity).where(
-            EntityOrm.dataset.notin_(complex_datasets),
-            EntityOrm.geometry.isnot(None),
-            func.ST_IsValid(EntityOrm.geometry),
-            func.ST_Contains(EntityOrm.geometry, func.ST_GeomFromText(point, 4326)),
-        )
+        if _searches_simple_datasets(simple_datasets):
+            branches.append(
+                select(EntityOrm.entity).where(
+                    _entity_dataset_filter(simple_datasets),
+                    EntityOrm.geometry.isnot(None),
+                    func.ST_IsValid(EntityOrm.geometry),
+                    func.ST_Contains(
+                        EntityOrm.geometry, func.ST_GeomFromText(point, 4326)
+                    ),
+                )
+            )
 
         # Combine using union_all
-        union_ids = union_all(subdivided_ids_query, entity_ids_query).subquery()
+        union_ids = _union_of(branches).subquery()
 
         # Step 2: Get full EntityOrm rows matching those IDs
         query = query.filter(EntityOrm.entity.in_(select(union_ids.c.entity)))
@@ -317,38 +378,45 @@ def _apply_location_filters(session, query, params):
     entity_matches = []
     for geometry in params.get("geometry", []):
         geom = func.ST_GeomFromText(geometry, 4326)
+        branches = []
 
         # Entities from entity_subdivided (for complex datasets)
-        subdivided_query = select(entity_subdivided_alias.entity).where(
-            entity_subdivided_alias.dataset.in_(complex_datasets),
-            entity_subdivided_alias.geometry_subdivided.isnot(None),
-            func.ST_IsValid(entity_subdivided_alias.geometry_subdivided),
-            spatial_function(entity_subdivided_alias.geometry_subdivided, geom),
-        )
+        if subdivided_datasets:
+            branches.append(
+                select(entity_subdivided_alias.entity).where(
+                    entity_subdivided_alias.dataset.in_(subdivided_datasets),
+                    entity_subdivided_alias.geometry_subdivided.isnot(None),
+                    func.ST_IsValid(entity_subdivided_alias.geometry_subdivided),
+                    spatial_function(entity_subdivided_alias.geometry_subdivided, geom),
+                )
+            )
 
         # Entities from EntityOrm (for all other datasets)
-        entity_query = select(EntityOrm.entity).where(
-            EntityOrm.dataset.notin_(complex_datasets),
-            or_(
-                and_(
-                    EntityOrm.geometry.is_not(None),
-                    func.ST_IsValid(EntityOrm.geometry),
-                    spatial_function(EntityOrm.geometry, geom),
-                ),
-                and_(
-                    EntityOrm.point.is_not(None),
-                    func.ST_IsValid(EntityOrm.point),
-                    spatial_function(EntityOrm.point, geom),
-                ),
-            ),
-        )
+        if _searches_simple_datasets(simple_datasets):
+            branches.append(
+                select(EntityOrm.entity).where(
+                    _entity_dataset_filter(simple_datasets),
+                    or_(
+                        and_(
+                            EntityOrm.geometry.is_not(None),
+                            func.ST_IsValid(EntityOrm.geometry),
+                            spatial_function(EntityOrm.geometry, geom),
+                        ),
+                        and_(
+                            EntityOrm.point.is_not(None),
+                            func.ST_IsValid(EntityOrm.point),
+                            spatial_function(EntityOrm.point, geom),
+                        ),
+                    ),
+                )
+            )
 
         # Combine results with UNION ALL
-        entity_matches.append(subdivided_query.union_all(entity_query))
+        entity_matches.append(_union_of(branches))
 
     # Combine all geometries' matching entities via UNION ALL
     if entity_matches:
-        unioned_entities_subq = union_all(*entity_matches).subquery()
+        unioned_entities_subq = _union_of(entity_matches).subquery()
         query = query.filter(
             EntityOrm.entity.in_(select(unioned_entities_subq.c.entity))
         )

--- a/tests/unit/data_access/test_entity_queries.py
+++ b/tests/unit/data_access/test_entity_queries.py
@@ -42,8 +42,9 @@ def test__apply_location_filters_for_simple_dataset(mocker):
         },
     )
     sql_str = str(result.statement.compile(compile_kwargs={"literal_binds": True}))
-    assert "entity_subdivided" in sql_str
-    assert "conservation-area" not in sql_str.split("FROM entity_subdivided")[1]
+    # no complex dataset was asked for, so entity_subdivided cannot contribute
+    # any rows and should not be scanned at all
+    assert "entity_subdivided" not in sql_str
 
 
 def test__apply_location_filters_for_both(mocker):
@@ -58,8 +59,37 @@ def test__apply_location_filters_for_both(mocker):
         },
     )
     sql_str = str(result.statement.compile(compile_kwargs={"literal_binds": True}))
-    assert "flood-risk-zone" in sql_str.split("FROM entity_subdivided")[1]
-    assert "conservation-area" not in sql_str.split("FROM entity_subdivided")[1]
+    subdivided_branch, entity_branch = sql_str.split("UNION ALL")
+
+    # the complex dataset is looked up in entity_subdivided...
+    assert "FROM entity_subdivided" in subdivided_branch
+    assert "flood-risk-zone" in subdivided_branch
+    assert "conservation-area" not in subdivided_branch
+
+    # ...and the simple one in entity, each filtered to only its own datasets
+    assert "FROM entity_subdivided" not in entity_branch
+    assert "conservation-area" in entity_branch
+    assert "flood-risk-zone" not in entity_branch
+
+
+def test__apply_location_filters_pushes_dataset_into_entity_branch(mocker):
+    """
+    The requested dataset must be applied inside the spatial subquery, not only
+    by the outer query, otherwise every dataset's geometries are searched.
+    """
+    query = Query(EntityOrm)
+    result = _apply_location_filters(
+        mocker.MagicMock(),
+        query,
+        params={
+            "geometry": ["MULTIPOLYGON((-0.1 52.5, -0.5 52.3, 0.0 52.1, -0.1 52.5))"],
+            "dataset": ["conservation-area"],
+        },
+    )
+    sql_str = str(result.statement.compile(compile_kwargs={"literal_binds": True}))
+    spatial_subquery = sql_str.split("WHERE entity.entity IN")[1]
+    assert "conservation-area" in spatial_subquery
+    assert "NOT IN" not in spatial_subquery
 
 
 def test__apply_location_filters_without_dataset(mocker):


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

### Change 1: stop searching datasets you didn't ask for:

Say someone asks for conservation areas inside a London-shaped box.

Before, the database did this:

- Find every entity of every dataset inside that box — title boundaries, listed buildings, flood zones, everything.
- Hand that whole pile back.
- Then throw away everything that wasn't a conservation area.

The old entity search applied the location filter across every dataset, even when a dataset filter was in place, so it found matches it was always going to throw away.

Queries such as:
- ?geometry=BBOX&dataset=X
- .geojson?geometry=BBOX&dataset=X

will be much more efficient.

### Change 2: stop fetching a copy of the shape you throw away

Every entity's map shape is stored once in the database. But the old query asked for it twice:

- once in the compact binary format, and
- once converted to GeoJSON text.
The .json response never includes the GeoJSON version — the code deletes it right before sending the reply. So the database was converting every shape, sending it across, and the app was parsing it, purely to bin it.

Essentially .json queries with no field parameters would fetch the geojson query twice for _geometry_geojson and _point_geojson from the DB (expensive ST_AsGeojson queries) and then would drop them anyway.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link https://github.com/orgs/digital-land/projects/15/views/1?pane=issue&itemId=228819063&issue=digital-land%7Cdigital-land%7C781
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Test with a url such as:

```
https://www.staging.planning.data.gov.uk/entity.json?dataset=conservation-area&geometry=POLYGON((-0.362224 51.672268, -0.362224 51.772268, -0.262224 51.772268, -0.262224 51.672268, -0.362224 51.672268))&limit=500
```

A 0.1° box around St Albans. Returns 36 conservation areas. This hits the path the PR changed — dataset pushed into the spatial subquery, entity_subdivided skipped entirely.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
No
## [optional] Are there any dependencies on other PRs or Work?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate geometry data in JSON responses when no specific fields are selected.
  - Improved spatial searches across simple and mixed datasets by applying dataset restrictions correctly.
  - Reduced unnecessary query processing for irrelevant or single-dataset branches.

- **Tests**
  - Expanded coverage for dataset-specific spatial filtering and query routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->