### PR TITLE
Add spacing between map colour keys

### DIFF
--- a/assets/stylesheets/component/map/scss/_layer-controls.scss
+++ b/assets/stylesheets/component/map/scss/_layer-controls.scss
@@ -48,6 +48,7 @@ $govuk-checkboxes-size: 40px;
   position: relative;
   margin-left: 53px;
   font-size: 1rem;
+  min-height: $govuk-checkboxes-size;
 }
 
 


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

In the Data layers overlay on the map we display rows of colour key, datalayer name, and checkbox. Currently, when the name only spans one line, the colour keys have no spacking between each other and the UI looks clumsy. The reason for this is due to the absolute positioning of the colour keys meaning that padding is not being applied correctly. This change provides a min height so that padding can be applied in that context.

Changes:
- Add min height to key so that padding is applied

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/786 

## QA Instructions, Screenshots, Recordings

| Before | After |
|--------|--------|
| <img width="352" height="398" alt="Screenshot 2026-08-20 at 14 13 56" src="https://github.com/user-attachments/assets/824b41be-d909-415a-b3c4-e46ad8bd3b99" /> | <img width="349" height="397" alt="Screenshot 2026-08-20 at 14 14 08" src="https://github.com/user-attachments/assets/24c30c6b-bd99-43ca-b383-854f0c7bad9d" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: _css only_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the consistency of map layer control labels by ensuring checkbox key elements meet the minimum GOV.UK checkbox height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->