### PR TITLE
648  Create new Data Providers page

### DIFF
--- a/application/core/models.py
+++ b/application/core/models.py
@@ -136,12 +136,6 @@ class DatasetCollectionModel(DigitalLandBaseModel):
     last_collection_attempt: Optional[date] = None
 
 
-class DatasetPublicationCountModel(DigitalLandBaseModel):
-    dataset_publication: str
-    expected_publisher_count: int
-    publisher_count: int
-
-
 class ProviderModel(DigitalLandBaseModel):
     dataset: str
     organisation: str

--- a/application/core/models.py
+++ b/application/core/models.py
@@ -142,6 +142,20 @@ class DatasetPublicationCountModel(DigitalLandBaseModel):
     publisher_count: int
 
 
+class ProviderModel(DigitalLandBaseModel):
+    dataset: str
+    organisation: str
+    organisation_name: Optional[str] = None
+    entity: Optional[int] = None
+    is_designated_provider: bool
+    has_active_endpoint: bool
+    has_active_resource: bool
+    owns_entities: bool
+    quality: Optional[str] = None
+    entity_count: int
+    quality_score: Optional[float] = None
+
+
 def entity_factory(entity_orm: EntityOrm):
     e = EntityModel.model_validate(entity_orm)
     if entity_orm.json is not None:

--- a/application/data_access/digital_land_queries.py
+++ b/application/data_access/digital_land_queries.py
@@ -10,6 +10,7 @@ from application.core.models import (
     OrganisationModel,
     DatasetCollectionModel,
     DatasetPublicationCountModel,
+    ProviderModel,
 )
 from application.db.session import redis_cache, DbSession
 from application.core.utils import log_slow_execution
@@ -20,6 +21,7 @@ from application.db.models import (
     TypologyOrm,
     DatasetCollectionOrm,
     DatasetPublicationCountOrm,
+    ProvisionQualityOrm,
 )
 
 logger = logging.getLogger(__name__)
@@ -134,6 +136,50 @@ def get_publisher_coverage(session: Session, dataset) -> DatasetPublicationCount
             expected_publisher_count=0,
             publisher_count=0,
         )
+
+
+def get_providers_for_dataset(session: Session, dataset) -> List[ProviderModel]:
+    """
+    A provider is defined as an organisation with an active endpoint
+    that does not have and enddate (i.e. is still in use) for this
+    dataset (has_active_endpoint=True).
+    """
+    resolved_name = func.coalesce(
+        ProvisionQualityOrm.organisation_name, OrganisationOrm.name
+    )
+    is_active_provider = ProvisionQualityOrm.has_active_endpoint.is_(True)
+
+    results = (
+        session.query(ProvisionQualityOrm, OrganisationOrm.entity, resolved_name)
+        .outerjoin(
+            OrganisationOrm,
+            OrganisationOrm.organisation == ProvisionQualityOrm.organisation,
+        )
+        .filter(ProvisionQualityOrm.dataset == dataset)
+        .filter(is_active_provider)
+        .order_by(resolved_name)
+        .all()
+    )
+    providers = []
+    for provision_quality, entity, organisation_name in results:
+        if not organisation_name:
+            continue
+        providers.append(
+            ProviderModel(
+                dataset=provision_quality.dataset,
+                organisation=provision_quality.organisation,
+                organisation_name=organisation_name,
+                entity=entity,
+                is_designated_provider=provision_quality.is_designated_provider,
+                has_active_endpoint=provision_quality.has_active_endpoint,
+                has_active_resource=provision_quality.has_active_resource,
+                owns_entities=provision_quality.owns_entities,
+                quality=provision_quality.quality,
+                entity_count=provision_quality.entity_count,
+                quality_score=provision_quality.quality_score,
+            )
+        )
+    return providers
 
 
 def get_latest_resource(session: Session, dataset) -> DatasetCollectionModel:

--- a/application/data_access/digital_land_queries.py
+++ b/application/data_access/digital_land_queries.py
@@ -9,7 +9,6 @@ from application.core.models import (
     TypologyModel,
     OrganisationModel,
     DatasetCollectionModel,
-    DatasetPublicationCountModel,
     ProviderModel,
 )
 from application.db.session import redis_cache, DbSession
@@ -20,7 +19,6 @@ from application.db.models import (
     OrganisationOrm,
     TypologyOrm,
     DatasetCollectionOrm,
-    DatasetPublicationCountOrm,
     ProvisionQualityOrm,
 )
 
@@ -124,18 +122,6 @@ def get_local_authorities(
         .all()
     )
     return [OrganisationModel.model_validate(o) for o in organisations]
-
-
-def get_publisher_coverage(session: Session, dataset) -> DatasetPublicationCountModel:
-    result = session.query(DatasetPublicationCountOrm).get(dataset)
-    if result is not None:
-        return DatasetPublicationCountModel.model_validate(result)
-    else:
-        return DatasetPublicationCountModel(
-            dataset_publication=dataset,
-            expected_publisher_count=0,
-            publisher_count=0,
-        )
 
 
 def get_providers_for_dataset(session: Session, dataset) -> List[ProviderModel]:

--- a/application/factory.py
+++ b/application/factory.py
@@ -29,6 +29,7 @@ from application.routers import (
     dataset,
     curie,
     organisation,
+    data_provider,
     fact,
     local_plans,
     task,
@@ -278,6 +279,7 @@ def add_routers(app):
     app.include_router(curie.router, prefix="/curie")
     app.include_router(curie.router, prefix="/prefix")
     app.include_router(organisation.router, prefix="/organisation")
+    app.include_router(data_provider.router, prefix="/data-provider")
     app.include_router(fact.router, prefix="/fact")
     app.include_router(local_plans.router, prefix="/local-plans")
     app.include_router(task.router, prefix="/task")

--- a/application/routers/data_provider.py
+++ b/application/routers/data_provider.py
@@ -1,0 +1,51 @@
+import logging
+
+from fastapi import APIRouter, Request, Depends, HTTPException, Path
+from starlette.responses import HTMLResponse
+from sqlalchemy.orm import Session
+
+from application.core.templates import templates
+from application.data_access.digital_land_queries import (
+    get_dataset_query,
+    get_providers_for_dataset,
+)
+from application.db.session import get_session
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def get_providers(
+    request: Request,
+    dataset: str = Path(description="Specify which dataset"),
+    session: Session = Depends(get_session),
+):
+    _dataset = get_dataset_query(session, dataset)
+    if _dataset is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"dataset '{dataset}' not found for data providers page",
+        )
+
+    providers = get_providers_for_dataset(session, dataset)
+    authoritative_providers = [p for p in providers if p.quality == "authoritative"]
+    alternative_providers = [p for p in providers if p.quality != "authoritative"]
+
+    return templates.TemplateResponse(
+        request,
+        "data_provider_index.html",
+        {
+            "dataset": _dataset,
+            "authoritative_providers": authoritative_providers,
+            "alternative_providers": alternative_providers,
+            "feedback_form_footer": True,
+        },
+    )
+
+
+router.add_api_route(
+    "/{dataset}",
+    endpoint=get_providers,
+    response_class=HTMLResponse,
+    include_in_schema=False,
+)

--- a/application/routers/dataset.py
+++ b/application/routers/dataset.py
@@ -16,6 +16,7 @@ from application.data_access.digital_land_queries import (
     get_latest_resource,
     get_publisher_coverage,
     get_dataset_coverage_status,
+    get_providers_for_dataset,
 )
 
 from application.data_access.entity_queries import get_entity_count, get_entity_search
@@ -141,6 +142,10 @@ def get_dataset(
         publisher_coverage = get_publisher_coverage(session, dataset)
         dataset_coverage_status = get_dataset_coverage_status(dataset)
 
+        providers = get_providers_for_dataset(session, dataset)
+        authoritative_providers = [p for p in providers if p.quality == "authoritative"]
+        alternative_providers = [p for p in providers if p.quality != "authoritative"]
+
         # TODO add test to check this table loads loads
         # for categoric datasets provide list of categories
         if _dataset.typology == "category":
@@ -190,6 +195,8 @@ def get_dataset(
                     "expected": publisher_coverage.expected_publisher_count,
                     "current": publisher_coverage.publisher_count,
                 },
+                "authoritative_providers": authoritative_providers,
+                "alternative_providers": alternative_providers,
                 "latest_resource": latest_resource,
                 "last_collection_attempt": (
                     latest_resource.last_collection_attempt if latest_resource else None

--- a/application/routers/dataset.py
+++ b/application/routers/dataset.py
@@ -14,7 +14,6 @@ from application.data_access.digital_land_queries import (
     get_dataset_query,
     get_all_datasets,
     get_latest_resource,
-    get_publisher_coverage,
     get_dataset_coverage_status,
     get_providers_for_dataset,
 )
@@ -139,7 +138,6 @@ def get_dataset(
             return _dataset
 
         latest_resource = get_latest_resource(session, dataset)
-        publisher_coverage = get_publisher_coverage(session, dataset)
         dataset_coverage_status = get_dataset_coverage_status(dataset)
 
         providers = get_providers_for_dataset(session, dataset)
@@ -191,10 +189,6 @@ def get_dataset(
             {
                 "dataset": _dataset,
                 "entity_count": entity_count[1] if entity_count else 0,
-                "publishers": {
-                    "expected": publisher_coverage.expected_publisher_count,
-                    "current": publisher_coverage.publisher_count,
-                },
                 "authoritative_providers": authoritative_providers,
                 "alternative_providers": alternative_providers,
                 "latest_resource": latest_resource,

--- a/application/templates/data_provider_index.html
+++ b/application/templates/data_provider_index.html
@@ -1,0 +1,92 @@
+{% extends "layouts/layout.html" %}
+{% set templateName = "dl-info/data_provider_index.html" %}
+
+{% block head %}
+	{{ super() }}
+	<meta name="generated-date" content="{{ now }}" />
+	<link rel="stylesheet" href="/static/stylesheets/application.css">
+{% endblock head %}
+
+{%- from "components/back-button/macro.jinja" import dlBackButton %}
+{% block breadcrumbs%}
+  {{ dlBackButton({
+    "parentHref": '/dataset/' + dataset["dataset"]
+  })}}
+{% endblock %}
+
+{% block pageTitle %}Data providers | {{ dataset["name"] }} | Planning Data{% endblock %}
+
+{%
+  set provider_groups = [
+    {
+      "id": "authoritative-sources",
+      "label": "Authoritative sources",
+      "providers": authoritative_providers,
+    },
+    {
+      "id": "alternative-sources",
+      "label": "Alternative sources",
+      "providers": alternative_providers,
+    },
+  ]
+%}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <span class="govuk-caption-xl">{{ dataset["name"] }}</span>
+      <h1 class="govuk-heading-xl">Data providers</h1>
+      <p class="govuk-body">These sources provide the data used in the {{ dataset["name"] }} dataset.</p>
+    </div>
+  </div>
+
+  <form class="dl-filter-organisations-list__form filter-organisations-list__form--active govuk-!-margin-bottom-9" data-module="dl-list-filter-form">
+
+    <!-- Text filter -->
+    <label class="dl-list-filter__label govuk-label govuk-!-font-weight-bold" for="filter-providers-list">Find a data provider</label>
+    <input class="dl-list-filter__input govuk-input govuk-!-margin-bottom-3" type="text" id="filter-providers-list">
+
+  </form>
+
+  {% for group in provider_groups if group.providers|length > 0 %}
+
+  <div class="govuk-grid-row dl-list-filter__count">
+    <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-m" id="{{ group.id }}">{{ group.label }}</h2>
+      <div class="dl-list-filter__count__wrapper">
+        <p class="govuk-visually-hidden">There {{"is" if group.providers|length == 1 else "are"}}
+          <span class="js-accessible-list-filter__count">{{ group.providers|length }}</span>
+          {{ group.label|lower }}
+        </p>
+        <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80 js-list-filter__count" aria-hidden="true">{{ group.providers|length }}</span>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+
+      <ol class="dl-list-filter__list" data-filter="list">
+        {% for provider in group.providers %}
+          <li class="dl-list-filter__item" data-filter="item">
+            {% if provider.entity %}
+              <a href="/entity/{{ provider.entity }}" class="govuk-link dl-list-filter__item-title">{{ provider.organisation_name or provider.organisation }}</a>
+            {% else %}
+              <span class="dl-list-filter__item-title">{{ provider.organisation_name or provider.organisation }}</span>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ol>
+    </div>
+  </div>
+  {% endfor %}
+
+  {% if authoritative_providers|length == 0 and alternative_providers|length == 0 %}
+    <p class="govuk-body">There are no known data providers for {{ dataset["name"] }}.</p>
+  {% endif %}
+
+  <div class="dl-list-filter__no-filter-match js-hidden">
+		<p class="govuk-body">No data provider for {{ dataset["name"] }} matches <span class="js-search-term-display"></span>.</p>
+	</div>
+
+  {% include "partials/feedback.html" without context %}
+{% endblock %}

--- a/application/templates/dataset.html
+++ b/application/templates/dataset.html
@@ -70,6 +70,23 @@
         'titleText': 'About this dataset'
       }) %}
 
+      {% set all_providers = authoritative_providers + alternative_providers %}
+      {% set total_provider_count = all_providers|length %}
+      {% if total_provider_count > 5 %}
+        {% set data_providers_html = '<a class="govuk-link" href="/data-provider/' + dataset["dataset"] + '">' + total_provider_count|commanum + ' data provider' + ('s' if total_provider_count != 1 else '') + '</a>' %}
+      {% else %}
+        {% set provider_links = [] %}
+        {% for provider in all_providers %}
+          {% if provider.entity %}
+            {% set link_html %}<div class="govuk-!-margin-bottom-1"><a class="govuk-link" href="/entity/{{ provider.entity }}">{{ provider.organisation_name or provider.organisation }}</a></div>{% endset %}
+          {% else %}
+            {% set link_html %}<div class="govuk-!-margin-bottom-1">{{ provider.organisation_name or provider.organisation }}</div>{% endset %}
+          {% endif %}
+          {{ provider_links.append(link_html) or '' }}
+        {% endfor %}
+        {% set data_providers_html = provider_links|join if provider_links else 'None' %}
+      {% endif %}
+
       {%
         set rows = [
           [
@@ -88,7 +105,7 @@
               'html': 'Data providers',
             },
             {
-              'html': publishers['current']|commanum,
+              'html': data_providers_html,
             },
           ],
           [

--- a/application/templates/partials/feedback.html
+++ b/application/templates/partials/feedback.html
@@ -6,7 +6,7 @@
       <p class="govuk-body"><a href="https://forms.microsoft.com/e/VfSR3Jp8Nu?origin=lprLink&r315037aa6db34b1fa96f65739afca51a={{ dataset["name"] | urlencode }}" class="govuk-link">Give feedback on this dataset</a>, or email your questions and corrections to <a href="mailto:{{ templateVar.email }}" class="govuk-link">{{ templateVar.email }}</a>.</p>
     {% else %}
     <h3 class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-margin-top-0">Help improve this page</h3>
-    <p class="govuk-body"><a href="https://forms.office.com/pages/responsepage.aspx?id=EGg0v32c3kOociSi7zmVqDYGoPLIlZdKnTFE6Z-rET1UNEJKWk03TkhQOUZCVUpOSDUzSUw1SVhWNCQlQCN0PWcu&route=shorturl">Give feedback on this page</a>, or email your questions and corrections to <a href="mailto:digitalland@communities.gov.uk">digitalland@communities.gov.uk</a>.</p>
+    <p class="govuk-body"><a href="https://forms.office.com/pages/responsepage.aspx?id=EGg0v32c3kOociSi7zmVqDYGoPLIlZdKnTFE6Z-rET1UNEJKWk03TkhQOUZCVUpOSDUzSUw1SVhWNCQlQCN0PWcu&route=shorturl" class="govuk-link">Give feedback on this page</a>, or email your questions and corrections to <a href="mailto:digitalland@communities.gov.uk" class="govuk-link">digitalland@communities.gov.uk</a>.</p>
     {% endif %}
   </div>
 </div>

--- a/tests/acceptance/test_data_provider.py
+++ b/tests/acceptance/test_data_provider.py
@@ -1,0 +1,162 @@
+import re
+
+from playwright.sync_api import expect
+
+from application.db.models import EntityOrm, OrganisationOrm, ProvisionQualityOrm
+
+
+def add_organisation(app_db_session, organisation, name, entity):
+    app_db_session.add(
+        OrganisationOrm(organisation=organisation, name=name, entity=entity)
+    )
+    app_db_session.add(
+        EntityOrm(
+            entity=entity,
+            name=name,
+            dataset="local-authority",
+            typology="organisation",
+            prefix="local-authority",
+            reference=organisation.split(":")[-1],
+        )
+    )
+
+
+def add_provision_quality(
+    app_db_session,
+    dataset,
+    organisation,
+    organisation_name,
+    is_designated_provider,
+):
+    app_db_session.add(
+        ProvisionQualityOrm(
+            dataset=dataset,
+            organisation=organisation,
+            organisation_name=organisation_name,
+            has_active_endpoint=True,
+            has_active_resource=True,
+            owns_entities=True,
+            is_designated_provider=is_designated_provider,
+            quality="authoritative" if is_designated_provider else "some",
+            entity_count=10,
+            quality_score=None,
+        )
+    )
+
+
+def test_data_provider_page_loads_ok(server_url, page, app_test_data, app_db_session):
+    add_organisation(
+        app_db_session, "local-authority:ACC-TEST", "Acceptance Test Council", 700001
+    )
+    add_provision_quality(
+        app_db_session,
+        "brownfield-site",
+        "local-authority:ACC-TEST",
+        "Acceptance Test Council",
+        is_designated_provider=True,
+    )
+    app_db_session.commit()
+
+    response = page.goto(server_url + "/data-provider/brownfield-site")
+    assert response.ok
+
+    heading = page.get_by_role("heading", name="Data providers")
+    assert heading.is_visible()
+
+    provider_link = page.get_by_role("link", name="Acceptance Test Council")
+    assert provider_link.is_visible()
+
+
+def test_navigate_to_data_provider_page_and_through_to_organisation(
+    server_url, page, app_test_data, app_db_session
+):
+    # The dataset page only links to the data providers page once there are
+    # more than 5 providers — 5 or fewer are shown inline instead. Seed extra
+    # filler providers so the link this test is exercising actually renders.
+    for i in range(5):
+        add_organisation(
+            app_db_session,
+            f"local-authority:ACC-FILLER{i}",
+            f"Filler Council {i}",
+            700010 + i,
+        )
+        add_provision_quality(
+            app_db_session,
+            "brownfield-site",
+            f"local-authority:ACC-FILLER{i}",
+            f"Filler Council {i}",
+            is_designated_provider=True,
+        )
+
+    add_organisation(
+        app_db_session, "local-authority:ACC-NAV", "Navigation Test Council", 700002
+    )
+    add_provision_quality(
+        app_db_session,
+        "brownfield-site",
+        "local-authority:ACC-NAV",
+        "Navigation Test Council",
+        is_designated_provider=True,
+    )
+    app_db_session.commit()
+
+    page.goto(server_url + "/dataset/brownfield-site")
+
+    provider_link = page.get_by_role("link", name="6 data providers")
+    with page.expect_navigation() as navigation_info:
+        provider_link.click()
+
+    assert navigation_info.value.ok
+    assert server_url + "/data-provider/brownfield-site" in navigation_info.value.url
+
+    heading = page.get_by_role("heading", name="Data providers")
+    assert heading.is_visible()
+
+    org_link = page.get_by_role("link", name="Navigation Test Council")
+    with page.expect_navigation() as org_navigation:
+        org_link.click()
+
+    assert org_navigation.value.ok
+    assert "/entity/700002" in org_navigation.value.url
+
+
+def test_data_provider_list_filter_works_as_expected(
+    server_url, page, app_test_data, app_db_session
+):
+    add_organisation(
+        app_db_session, "local-authority:ACC-A", "Aardvark Council", 700003
+    )
+    add_organisation(app_db_session, "local-authority:ACC-Z", "Zebra Council", 700004)
+    add_provision_quality(
+        app_db_session,
+        "brownfield-site",
+        "local-authority:ACC-A",
+        "Aardvark Council",
+        is_designated_provider=True,
+    )
+    add_provision_quality(
+        app_db_session,
+        "brownfield-site",
+        "local-authority:ACC-Z",
+        "Zebra Council",
+        is_designated_provider=True,
+    )
+    app_db_session.commit()
+
+    page.goto(server_url + "/data-provider/brownfield-site")
+
+    filter_form = page.locator("form[data-module='dl-list-filter-form']")
+    expect(filter_form).to_have_class(re.compile(r"list-filter__form--active"))
+
+    filter_input = page.locator("input.dl-list-filter__input")
+    visible_items = page.locator("li.dl-list-filter__item:not(.js-hidden) >> a")
+
+    filter_input.fill("Aardvark")
+    expect(visible_items).to_have_count(1)
+    assert visible_items.all()[0].text_content() == "Aardvark Council"
+
+    filter_input.fill("a string that wont find anything")
+    expect(visible_items).to_have_count(0)
+
+    no_match_message = page.locator(".dl-list-filter__no-filter-match")
+    expect(no_match_message).to_be_visible()

--- a/tests/integration/data_access/test_provider_queries.py
+++ b/tests/integration/data_access/test_provider_queries.py
@@ -1,0 +1,168 @@
+from application.db.models import OrganisationOrm, ProvisionQualityOrm
+from application.data_access.digital_land_queries import get_providers_for_dataset
+
+
+def add_provision_quality(
+    db_session,
+    dataset="greenspace",
+    organisation="local-authority:X",
+    organisation_name="Test Council",
+    is_designated_provider=True,
+    quality="authoritative",
+    has_active_endpoint=True,
+):
+    db_session.add(
+        ProvisionQualityOrm(
+            dataset=dataset,
+            organisation=organisation,
+            organisation_name=organisation_name,
+            has_active_endpoint=has_active_endpoint,
+            has_active_resource=True,
+            owns_entities=True,
+            is_designated_provider=is_designated_provider,
+            quality=quality,
+            entity_count=10,
+            quality_score=None,
+        )
+    )
+
+
+class TestGetProvidersForDataset:
+    def test_returns_empty_list_when_no_providers(self, db_session):
+        result = get_providers_for_dataset(db_session, "greenspace")
+        assert result == []
+
+    def test_returns_provider_with_entity_from_organisation_table(self, db_session):
+        db_session.add(
+            OrganisationOrm(
+                organisation="local-authority:X", name="Test Council", entity=100
+            )
+        )
+        add_provision_quality(db_session)
+        db_session.flush()
+
+        result = get_providers_for_dataset(db_session, "greenspace")
+
+        assert len(result) == 1
+        provider = result[0]
+        assert provider.organisation == "local-authority:X"
+        assert provider.organisation_name == "Test Council"
+        assert provider.entity == 100
+        assert provider.is_designated_provider is True
+
+    def test_returns_none_entity_when_no_matching_organisation(self, db_session):
+        add_provision_quality(
+            db_session, organisation="unknown:Y", organisation_name="Unknown Org"
+        )
+        db_session.flush()
+
+        result = get_providers_for_dataset(db_session, "greenspace")
+
+        assert len(result) == 1
+        assert result[0].entity is None
+
+    def test_only_returns_providers_for_requested_dataset(self, db_session):
+        add_provision_quality(db_session, dataset="greenspace")
+        add_provision_quality(
+            db_session, dataset="forest", organisation="local-authority:Z"
+        )
+        db_session.flush()
+
+        result = get_providers_for_dataset(db_session, "forest")
+
+        assert len(result) == 1
+        assert result[0].dataset == "forest"
+
+    def test_distinguishes_authoritative_and_alternative_providers(self, db_session):
+        add_provision_quality(
+            db_session,
+            organisation="local-authority:A",
+            organisation_name="Authoritative Council",
+            is_designated_provider=True,
+        )
+        add_provision_quality(
+            db_session,
+            organisation="local-authority:B",
+            organisation_name="Alternative Council",
+            is_designated_provider=False,
+            quality="some",
+        )
+        db_session.flush()
+
+        result = get_providers_for_dataset(db_session, "greenspace")
+
+        authoritative = [p for p in result if p.is_designated_provider]
+        alternative = [p for p in result if not p.is_designated_provider]
+        assert len(authoritative) == 1
+        assert authoritative[0].organisation_name == "Authoritative Council"
+        assert len(alternative) == 1
+        assert alternative[0].organisation_name == "Alternative Council"
+
+    def test_falls_back_to_organisation_table_name_when_provision_quality_name_is_null(
+        self, db_session
+    ):
+        db_session.add(
+            OrganisationOrm(
+                organisation="local-authority:X", name="Test Council", entity=100
+            )
+        )
+        add_provision_quality(db_session, organisation_name=None)
+        db_session.flush()
+
+        result = get_providers_for_dataset(db_session, "greenspace")
+
+        assert len(result) == 1
+        assert result[0].organisation_name == "Test Council"
+
+    def test_skips_provider_when_no_name_available_from_either_source(self, db_session):
+        add_provision_quality(
+            db_session, organisation="unknown:Y", organisation_name=None
+        )
+        db_session.flush()
+
+        result = get_providers_for_dataset(db_session, "greenspace")
+
+        assert result == []
+
+    def test_excludes_provider_with_no_active_endpoint(self, db_session):
+        add_provision_quality(
+            db_session,
+            organisation="local-authority:A",
+            organisation_name="Decommissioned Council",
+            has_active_endpoint=False,
+        )
+        add_provision_quality(
+            db_session,
+            organisation="local-authority:B",
+            organisation_name="Active Council",
+            has_active_endpoint=True,
+        )
+        db_session.flush()
+
+        result = get_providers_for_dataset(db_session, "greenspace")
+
+        names = [p.organisation_name for p in result]
+        assert names == ["Active Council"]
+
+    def test_does_not_error_when_provider_has_no_name(self, db_session):
+        add_provision_quality(
+            db_session,
+            organisation="local-authority:A",
+            organisation_name="Zebra Council",
+        )
+        add_provision_quality(
+            db_session,
+            organisation="local-authority:B",
+            organisation_name=None,
+        )
+        add_provision_quality(
+            db_session,
+            organisation="local-authority:C",
+            organisation_name="Aardvark Council",
+        )
+        db_session.flush()
+
+        result = get_providers_for_dataset(db_session, "greenspace")
+
+        names = [p.organisation_name for p in result]
+        assert names == ["Aardvark Council", "Zebra Council"]

--- a/tests/integration/test_data_provider.py
+++ b/tests/integration/test_data_provider.py
@@ -1,0 +1,160 @@
+from bs4 import BeautifulSoup
+
+from application.db.models import OrganisationOrm, ProvisionQualityOrm
+
+
+def add_provision_quality(
+    db_session,
+    dataset,
+    organisation,
+    organisation_name,
+    is_designated_provider,
+):
+    db_session.add(
+        ProvisionQualityOrm(
+            dataset=dataset,
+            organisation=organisation,
+            organisation_name=organisation_name,
+            has_active_endpoint=True,
+            has_active_resource=True,
+            owns_entities=True,
+            is_designated_provider=is_designated_provider,
+            quality="authoritative" if is_designated_provider else "some",
+            entity_count=10,
+            quality_score=None,
+        )
+    )
+
+
+def test_provider_page_groups_providers_by_authoritative_and_alternative(
+    client, db_session, test_data, exclude_middleware
+):
+    db_session.add(
+        OrganisationOrm(
+            organisation="local-authority:AUTH",
+            name="Authoritative Council",
+            entity=600001,
+        )
+    )
+    db_session.add(
+        OrganisationOrm(
+            organisation="local-authority:ALT",
+            name="Alternative Council",
+            entity=600002,
+        )
+    )
+    add_provision_quality(
+        db_session,
+        "greenspace",
+        "local-authority:AUTH",
+        "Authoritative Council",
+        is_designated_provider=True,
+    )
+    add_provision_quality(
+        db_session,
+        "greenspace",
+        "local-authority:ALT",
+        "Alternative Council",
+        is_designated_provider=False,
+    )
+    db_session.flush()
+
+    response = client.get("/data-provider/greenspace")
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    authoritative_section = soup.find(id="authoritative-sources").find_parent(
+        class_="dl-list-filter__count"
+    )
+    alternative_section = soup.find(id="alternative-sources").find_parent(
+        class_="dl-list-filter__count"
+    )
+
+    authoritative_link = authoritative_section.find("a", href="/entity/600001")
+    assert authoritative_link is not None
+    assert authoritative_link.get_text(strip=True) == "Authoritative Council"
+
+    alternative_link = alternative_section.find("a", href="/entity/600002")
+    assert alternative_link is not None
+    assert alternative_link.get_text(strip=True) == "Alternative Council"
+
+    # Confirm each provider only appears in its own section
+    assert authoritative_section.find("a", href="/entity/600002") is None
+    assert alternative_section.find("a", href="/entity/600001") is None
+
+
+def test_provider_page_returns_404_for_unknown_dataset(
+    client, db_session, test_data, exclude_middleware
+):
+    response = client.get("/data-provider/not-a-real-dataset")
+
+    assert response.status_code == 404
+
+
+def test_provider_page_hides_heading_for_empty_group(
+    client, db_session, test_data, exclude_middleware
+):
+    db_session.add(
+        OrganisationOrm(
+            organisation="local-authority:AUTH",
+            name="Authoritative Council",
+            entity=600003,
+        )
+    )
+    add_provision_quality(
+        db_session,
+        "greenspace",
+        "local-authority:AUTH",
+        "Authoritative Council",
+        is_designated_provider=True,
+    )
+    db_session.flush()
+
+    response = client.get("/data-provider/greenspace")
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    assert soup.find(id="authoritative-sources") is not None
+    assert soup.find(id="alternative-sources") is None
+
+
+def test_provider_page_shows_intro_text_with_dynamic_dataset_name(
+    client, db_session, test_data, exclude_middleware
+):
+    response = client.get("/data-provider/greenspace")
+
+    assert response.status_code == 200
+    assert (
+        "These sources provide the data used in the Greenspace dataset."
+        in response.text
+    )
+
+
+def test_provider_page_no_match_message_includes_dataset_name(
+    client, db_session, test_data, exclude_middleware
+):
+    response = client.get("/data-provider/greenspace")
+
+    assert response.status_code == 200
+    assert "No data provider for Greenspace matches" in response.text
+
+
+def test_provider_page_shows_visible_empty_state_when_no_providers_exist(
+    client, db_session, test_data, exclude_middleware
+):
+    response = client.get("/data-provider/greenspace")
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    empty_state = soup.find(
+        "p",
+        string=lambda text: text and "no known data providers" in text.lower(),
+    )
+    assert empty_state is not None
+    assert "Greenspace" in empty_state.get_text()
+    # This message must be visible by default, unlike the JS-only no-match
+    # message which only appears after a search yields nothing.
+    assert empty_state.find_parent(class_="js-hidden") is None

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -1,0 +1,106 @@
+from bs4 import BeautifulSoup
+
+from application.db.models import OrganisationOrm, ProvisionQualityOrm
+
+
+def add_provision_quality(
+    db_session,
+    dataset,
+    organisation,
+    organisation_name,
+    is_designated_provider,
+):
+    db_session.add(
+        ProvisionQualityOrm(
+            dataset=dataset,
+            organisation=organisation,
+            organisation_name=organisation_name,
+            has_active_endpoint=True,
+            has_active_resource=True,
+            owns_entities=True,
+            is_designated_provider=is_designated_provider,
+            quality="authoritative" if is_designated_provider else "some",
+            entity_count=10,
+            quality_score=None,
+        )
+    )
+
+
+def add_provider(db_session, suffix, entity, is_designated_provider):
+    name = f"Council {suffix}"
+    db_session.add(
+        OrganisationOrm(
+            organisation=f"local-authority:{suffix}", name=name, entity=entity
+        )
+    )
+    add_provision_quality(
+        db_session,
+        "greenspace",
+        f"local-authority:{suffix}",
+        name,
+        is_designated_provider=is_designated_provider,
+    )
+    return name
+
+
+def test_dataset_page_shows_providers_inline_when_five_or_fewer_exist(
+    client, db_session, test_data, exclude_middleware
+):
+    """
+    A mix of authoritative and alternative providers, totalling exactly 5 —
+    the rule is a count threshold regardless of provider type.
+    """
+    entities = [600020, 600021, 600022, 600023, 600024]
+    names = [
+        add_provider(db_session, "A1", entities[0], is_designated_provider=True),
+        add_provider(db_session, "A2", entities[1], is_designated_provider=True),
+        add_provider(db_session, "B1", entities[2], is_designated_provider=False),
+        add_provider(db_session, "B2", entities[3], is_designated_provider=False),
+        add_provider(db_session, "B3", entities[4], is_designated_provider=False),
+    ]
+    db_session.flush()
+
+    response = client.get("/dataset/greenspace")
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    assert soup.find("a", href="/data-provider/greenspace") is None
+
+    for entity, name in zip(entities, names):
+        inline_link = soup.find("a", href=f"/entity/{entity}")
+        assert inline_link is not None
+        assert inline_link.get_text(strip=True) == name
+
+
+def test_dataset_page_links_to_providers_when_more_than_five_exist(
+    client, db_session, test_data, exclude_middleware
+):
+    for i in range(6):
+        add_provider(
+            db_session, f"C{i}", 600030 + i, is_designated_provider=(i % 2 == 0)
+        )
+    db_session.flush()
+
+    response = client.get("/dataset/greenspace")
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+    provider_link = soup.find("a", href="/data-provider/greenspace")
+    assert provider_link is not None
+    assert provider_link.get_text(strip=True) == "6 data providers"
+
+
+def test_dataset_page_shows_none_when_no_providers_at_all(
+    client, db_session, test_data, exclude_middleware
+):
+    response = client.get("/dataset/greenspace")
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    assert soup.find("a", href="/data-provider/greenspace") is None
+
+    row_heading = soup.find(string="Data providers")
+    row_value_cell = row_heading.find_parent("tr").find_all("td")[0]
+    assert row_value_cell.get_text(strip=True) == "None"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On the existing Dataset page, we show in the main data table, a row that displays the total number of data providers for this dataset. It does not currently provide any other information on those providers. We want to enable the user to see where the data is sourced from, improving confidence in our data.

To facilitate this, we are creating a new Data Providers page. the page will list all providers categorised by alternative and authoritative sources. 

On the dataset page, the dataset table will display the same row with the number of data providers, but instead of a static number, it is linked to the Data Providers page, where each Provider is linked to the correlating entity on the system. 

If the number of providers is 5 or less, the dataset page will list the providers inline within the table to save the user navigating away from the dataset page. 

The Data Providers page follows the design and the implementation of the Organisations page.

**Definition of authoritative/non-authoritative**

Authoritative and Alternative sources are defined by the quality column in the provision quality table. If quality = "authoritative" then authoritative else alternative.

Documented definition of values:

| Provision quality - `quality` field | definition |
|--------|--------|
| Authoritative | We have some data from the authoritative source |
| Some | We have some data from an alternative source | 

_(Work is still ongoing at the time of development to improve the provision quality data, with the implementation of quality scores still to be decided. Currently the authoritative source should be the owner/creator of that data. alternative sources may be handling third party data). https://digital-land.github.io/technical-documentation/data-operations-manual/Explanation/Key-Concepts/Data-Quality/Data-quality-2-framework/_

**Definition of provider**

Following discussions with the data team, we have decided that the definition of provider should be providers with an active endpoint. There may be historical providers which are excluded by this definition, but there are also edge cases where providers may no longer exist or organisations have merged. Reducing to current providers simplifies this. 

This is not a strict definition and could be updated in future. 

**Changes:**
- Create new Data Providers page
- Establish routing to Data Providers page
- Create Provider Model
- Update Dataset page to link to Data Providers page
- Add tests
- Acceptance/E2E tests
- Fix bug with missing govuk-link class in shared footer

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/648

## QA Instructions, Screenshots, Recordings

#### Dataset page updates

| Scenario | Before | After |
|--------|--------|--------|
| Dataset page: More than 5 providers (link to data-provider page) | <img width="1075" height="1247" alt="Screenshot 2026-09-01 at 14 21 31" src="https://github.com/user-attachments/assets/51862d2f-2432-400c-9d0a-27596efc3012" /> | <img width="1056" height="1269" alt="Screenshot 2026-09-01 at 14 23 07" src="https://github.com/user-attachments/assets/19750e3a-3e16-47d4-a300-5a58cd61ffbd" /> |
| Dataset page: 5 or less providers (list providers inline) | <img width="1030" height="1046" alt="Screenshot 2026-09-01 at 14 31 45" src="https://github.com/user-attachments/assets/65d4d475-fcaf-4302-ad7b-f0c2e95837e8" /> | <img width="1012" height="1096" alt="Screenshot 2026-09-01 at 14 31 28" src="https://github.com/user-attachments/assets/a54b832c-67c6-4f7c-b55f-e29aff02d17a" /> |
| No providers |  | <img width="1034" height="1254" alt="Screenshot 2026-09-01 at 14 59 52" src="https://github.com/user-attachments/assets/a66c1af6-73b1-4574-9488-ac08bbdd6066" /> |

#### Data Providers page

| Scenario | After |
|--------|--------|
| Full list | <img width="1147" height="7422" alt="data-provider-full-list" src="https://github.com/user-attachments/assets/3ff8b5ef-6794-4e1a-ac3e-daeeaf4ffb66" /> |
| Filtered list | <img width="1015" height="676" alt="Screenshot 2026-09-01 at 14 53 14" src="https://github.com/user-attachments/assets/b44c8d3d-ad9e-4fbf-be4d-18f4127ea9ea" /> | 
| No results: Filtered | <img width="1012" height="424" alt="Screenshot 2026-09-01 at 14 55 34" src="https://github.com/user-attachments/assets/77798326-cc65-4068-8b84-d780a957c734" /> | 
| No results: On page load (unfiltered) | <img width="1025" height="460" alt="Screenshot 2026-09-01 at 14 58 12" src="https://github.com/user-attachments/assets/97218002-220e-4314-ad3a-6092938874b4" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated data-provider page for each dataset.
  * Providers are grouped into authoritative and alternative sections, with organisation links and entity details where available.
  * Added provider filtering, counts, breadcrumbs, dataset information and no-match messaging.
  * Dataset pages now display provider information and link to the full provider list.
  * Provider lists show individual entries for five or fewer providers, or a total count for larger lists.
  * Added an empty state when no providers are available.

* **Bug Fixes**
  * Unknown dataset provider pages now return a 404 response.
  * Providers without identifiable names are excluded from displayed results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->