### PR TITLE
WCAG 2.2. - DAC Change in Status 01 - Dataset filtering updates result counts without announcing status changes to screen reader users

### DIFF
--- a/application/core/filters.py
+++ b/application/core/filters.py
@@ -280,6 +280,22 @@ def get_entity_paint_options(entity, datasets):
         return entity_datasets[0]["paint_options"]
 
 
+def pluralize(count, singular, plural=None):
+    """
+    Args:
+        count (int)
+        singular (str): singular word "result", "is", etc...
+        plural (str): plural word "results", "are", etc...
+
+    Returns:
+        str: Returns singular or plural word depending on count,
+        if plural word not provided, it appends "s" to singular word
+    """
+    if plural is None:
+        plural = singular + "s"
+    return singular if count == 1 else plural
+
+
 def commanum_filter(v):
     """
     Makes large numbers readable by adding commas

--- a/application/core/templates.py
+++ b/application/core/templates.py
@@ -27,6 +27,7 @@ from application.core.filters import (
     get_os_oauth2_token,
     format_date,
     is_past_date,
+    pluralize,
 )
 
 from application.core.utils import model_dumps
@@ -93,6 +94,7 @@ templates.env.filters["extract_component_key"] = extract_component_key
 templates.env.filters["get_entity_geometry"] = get_entity_geometry
 templates.env.filters["format_date"] = format_date
 templates.env.filters["is_past_date"] = is_past_date
+templates.env.filters["pluralize"] = pluralize
 
 # TODO This is a filter which should only need one variable, apparently ther
 # eis something called context processors that we should use

--- a/application/templates/data_provider_index.html
+++ b/application/templates/data_provider_index.html
@@ -55,10 +55,7 @@
     <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-m" id="{{ group.id }}">{{ group.label }}</h2>
       <div class="dl-list-filter__count__wrapper">
-        <p class="govuk-visually-hidden">There {{"is" if group.providers|length == 1 else "are"}}
-          <span class="js-accessible-list-filter__count">{{ group.providers|length }}</span>
-          {{ group.label|lower }}
-        </p>
+        <p class="govuk-visually-hidden js-accessible-list-filter__status" role="status" data-category="{{ group.label|lower }}">There {{ group.providers|length | pluralize("is", "are") }} {{ group.providers|length }} {{ group.providers|length | pluralize("result") }} in {{ group.label|lower }}</p>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80 js-list-filter__count" aria-hidden="true">{{ group.providers|length }}</span>
       </div>
     </div>
@@ -84,7 +81,7 @@
     <p class="govuk-body">There are no known data providers for {{ dataset["name"] }}.</p>
   {% endif %}
 
-  <div class="dl-list-filter__no-filter-match js-hidden">
+  <div class="dl-list-filter__no-filter-match js-hidden" role="status" aria-atomic="true">
 		<p class="govuk-body">No data provider for {{ dataset["name"] }} matches <span class="js-search-term-display"></span>.</p>
 	</div>
 

--- a/application/templates/dataset_index.html
+++ b/application/templates/dataset_index.html
@@ -49,10 +49,7 @@
 		{% set plural = typology | replace("-"," ")| title %}
 			<h2 class="govuk-heading-m" id="{{typology}}">{{plural}}</h2>
 			<div class="dl-list-filter__count__wrapper">
-				<p class="govuk-visually-hidden">There {{"is" if typologies[typology]['dataset']|length == 1 else "are"}}
-					<span class="js-accessible-list-filter__count">{{ typologies[typology]['dataset']|length }}</span>
-					{{plural}}
-				</p>
+				<p class="govuk-visually-hidden js-accessible-list-filter__status" role="status" data-category="{{ plural }}">There {{ typologies[typology]['dataset']|length | pluralize("is", "are") }} {{ typologies[typology]['dataset']|length }} {{ typologies[typology]['dataset']|length | pluralize("result") }} in {{plural}}</p>
 				<span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80 js-list-filter__count" aria-hidden="true">{{ typologies[typology]['dataset']|length }}</span>
 			</div>
 		</div>
@@ -75,7 +72,7 @@
 	{% endif %}
 	{% endfor %}
 
-	<div class="dl-list-filter__no-filter-match js-hidden">
+	<div class="dl-list-filter__no-filter-match js-hidden" role="status" aria-atomic="true">
 		<p class="govuk-body">No dataset matches <span class="js-search-term-display"></span>.</p>
 		<p class="govuk-body">
 			Check <a href="https://design.planning.data.gov.uk/what-we-are-working-on">our current priorities</a> to see if

--- a/application/templates/organisation_index.html
+++ b/application/templates/organisation_index.html
@@ -57,10 +57,7 @@
     <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-m" id="{{org_type}}">{%  if display_names.get(org_type) %}{{ display_names[org_type] }}{% else %}{{ org_type | replace("-", " ") | capitalize }}{% endif %}</h2>
       <div class="dl-list-filter__count__wrapper">
-        <p class="govuk-visually-hidden">There {{"is" if organisations[org_type]|length == 1 else "are"}}
-          <span class="js-accessible-list-filter__count">{{ organisations[org_type]|length }}</span>
-          {{org_type}}
-        </p>
+        <p class="govuk-visually-hidden js-accessible-list-filter__status" role="status" data-category="{{ org_type }}">There {{ organisations[org_type]|length | pluralize("is", "are") }} {{ organisations[org_type]|length }} {{ organisations[org_type]|length | pluralize("result") }} in {{org_type}}</p>
         <span class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-80 js-list-filter__count" aria-hidden="true">{{ organisations[org_type]|length }}</span>
       </div>
     </div>
@@ -84,7 +81,7 @@
   </div>
   {% endfor %}
 
-  <div class="dl-list-filter__no-filter-match js-hidden">
+  <div class="dl-list-filter__no-filter-match js-hidden" role="status" aria-atomic="true">
 		<p class="govuk-body">No dataset matches <span class="js-search-term-display"></span>.</p>
 		<p class="govuk-body">
 			Check <a href="https://design.planning.data.gov.uk/what-we-are-working-on">our current priorities</a> to see if

--- a/assets/javascripts/ListFilter.js
+++ b/assets/javascripts/ListFilter.js
@@ -105,13 +105,22 @@ export class ListFilter{
           let listSection = list.closest(list_section_selector);
           let countWrapper = listSection.querySelector(count_wrapper_selector);
           let listCount = countWrapper.querySelector('.js-list-filter__count');
-          let accessibleListCount = countWrapper.querySelector('.js-accessible-list-filter__count');
+          let accessibleStatus = countWrapper.querySelector('.js-accessible-list-filter__status');
 
           // show/hide sections with matching items
           if (matchingCount > 0) {
             listSection.classList.remove('js-hidden');
             listCount.textContent = matchingCount;
-            accessibleListCount.textContent = matchingCount;
+            if (accessibleStatus) {
+              const verb = matchingCount === 1 ? 'is' : 'are';
+              const noun = matchingCount === 1 ? 'result' : 'results';
+              const category = accessibleStatus.dataset.category;
+              const newStatusMessage = `There ${verb} ${matchingCount} ${noun} in ${category}`;
+              const statusMessageHasChanged = accessibleStatus.textContent !== newStatusMessage;
+              if (statusMessageHasChanged) {
+                accessibleStatus.textContent = newStatusMessage;
+              }
+            }
           } else {
             listSection.classList.add('js-hidden');
           }

--- a/tests/accessibility/test_dataset_accessibility.py
+++ b/tests/accessibility/test_dataset_accessibility.py
@@ -1,0 +1,34 @@
+import re
+
+from bs4 import BeautifulSoup
+
+
+def test_dataset_index_page_exposes_filter_result_count_as_a_status_message(
+    client, db_session, test_data, exclude_middleware
+):
+    """
+    WCAG 4.1.3 Status Messages: filtering the dataset list updates a
+    visually-hidden result count via JavaScript, but a screen reader only
+    announces that change if the count lives inside a role="status" live
+    region. Without it, filtering silently changes the results with no
+    indication to screen reader users that anything happened.
+
+    This checks the server-rendered markup carries that wiring on initial
+    load — the dynamic wording update itself is covered by the JS unit
+    test in tests/unit/javascript/ListFilter.test.js.
+
+    Not duplicated for organisation_index.html / data_provider_index.html:
+    they render the exact same list-filter markup, JS, and `pluralize`
+    filter, so this one test already covers all three. If either page's
+    filter ever diverges from this shared pattern, give it its own test.
+    """
+    response = client.get("/dataset/")
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    status_messages = soup.select(".dl-list-filter__count__wrapper p")
+
+    assert status_messages, "expected at least one list-filter result count on the page"
+    for status in status_messages:
+        assert status.get("role") == "status"
+        assert re.search(r"\d", status.get_text())

--- a/tests/unit/javascript/ListFilter.test.js
+++ b/tests/unit/javascript/ListFilter.test.js
@@ -230,7 +230,6 @@ describe('ListFilter', () => {
         let lists;
         let countWrapper;
         let listCount;
-        let accessibleListCount;
         let noMatches;
         let listFilterMock;
 
@@ -241,7 +240,7 @@ describe('ListFilter', () => {
                 <div class="list-section">
                   <div class="count-wrapper">
                     <span class="js-list-filter__count"></span>
-                    <span class="js-accessible-list-filter__count"></span>
+                    <p class="js-accessible-list-filter__status" data-category="Category"></p>
                   </div>
                   <div data-filter="list">
                     <div data-filter="item"></div>
@@ -251,7 +250,7 @@ describe('ListFilter', () => {
                 <div class="list-section">
                   <div class="count-wrapper">
                     <span class="js-list-filter__count"></span>
-                    <span class="js-accessible-list-filter__count"></span>
+                    <p class="js-accessible-list-filter__status" data-category="Category"></p>
                   </div>
                   <div data-filter="list">
                     <div data-filter="item"></div>
@@ -265,7 +264,6 @@ describe('ListFilter', () => {
           lists = dom.window.document.querySelectorAll('[data-filter="list"]');
           countWrapper = dom.window.document.querySelector('.count-wrapper');
           listCount = dom.window.document.querySelector('.js-list-filter__count');
-          accessibleListCount = dom.window.document.querySelector('.js-accessible-list-filter__count');
           noMatches = dom.window.document.querySelector('.dl-list-filter__no-filter-match');
 
             listFilterMock = {
@@ -282,7 +280,9 @@ describe('ListFilter', () => {
           expect(lists[0].closest('.list-section').classList.contains('js-hidden')).toBe(false);
           expect(lists[1].closest('.list-section').classList.contains('js-hidden')).toBe(false);
           expect(listCount.textContent).toBe('1');
-          expect(accessibleListCount.textContent).toBe('1');
+          expect(countWrapper.querySelector('.js-accessible-list-filter__status').textContent).toBe(
+            'There is 1 result in Category'
+          );
         });
 
         it('should show the "no matches" message if there are no matches', () => {
@@ -292,6 +292,23 @@ describe('ListFilter', () => {
           lists[1].querySelectorAll('[data-filter="item"]')[1].classList.add('js-hidden');
           listFilterMock.updateListCounts(lists);
           expect(noMatches.classList.contains('js-hidden')).toBe(false);
+        });
+
+        it('should announce singular wording for a single match and plural wording for multiple matches', () => {
+          lists[0].querySelectorAll('[data-filter="item"]')[0].classList.add('js-hidden');
+          listFilterMock.updateListCounts(lists);
+
+          const statuses = dom.window.document.querySelectorAll('.js-accessible-list-filter__status');
+
+          // Written as one plain sentence, not separate nested spans:
+          // VoiceOver reads a status region's own text and its child
+          // elements as two separate groups rather than in source order.
+
+          // list[0] has 1 matching item remaining
+          expect(statuses[0].textContent).toBe('There is 1 result in Category');
+
+          // list[1] has 2 matching items remaining
+          expect(statuses[1].textContent).toBe('There are 2 results in Category');
         });
     });
 


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

**WCAG Ref.:** 4.1.3 Status Messages (Level AA)

Dataset filtering updates result counts without announcing status changes to screen reader users

When users enter text into the dataset filter input field, the number of search results updates dynamically on the page.

Although a visually hidden result count exists, screen reader users are not informed when the number of results changes because the content is not exposed as a status message.

As a result, users may not be aware that their search has filtered the results or how many results remain.

**Update to DOM structure**

The element structure has been updated a little here as it was apparent in testing that Assistive voiceover tools would selectively order nested elements, resulting in nested items being read last, rather than the text being read out in the natural order that it appears in the DOM. Hence the full sentence is being generated and served to the page instead of only updating the number, or selected parts of the sentence.  

**Accessibility test**

A new accessibility test file has been added for the dataset page. The test inside actually tests a function used on all 3 pages that this change applies to, but the intention is to follow a similar pattern to integration tests where we mainly test at page level. It's difficult to apply automated testing to guard against future regressions on some of these accessibility changes, but the assertion that the status role exists acts as a guard nonetheless.

**Changes:**
- Add role status so assistive tech can announce updates automatically
- Add aria-atomic so that full live region is announced
- Improve wording

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/digital-land/digital-land/issues/735

## QA Instructions, Screenshots, Recordings

DOM output

_*Note: The number is different in this example because it's comparing dev/prod with different data sources_

| Before | After |
|--------|--------|
| <img width="468" height="128" alt="Screenshot 2026-09-09 at 12 02 50" src="https://github.com/user-attachments/assets/da154eb0-44c2-4c61-a2d8-5680af1561c6" /> | <img width="811" height="112" alt="Screenshot 2026-09-09 at 12 03 15" src="https://github.com/user-attachments/assets/028d31c6-5004-4283-bc0e-6ae48fbb4ccd" /> | 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved screen-reader announcements for result counts across provider, dataset, organisation and filtered-list views.
  - Counts now use grammatically correct singular or plural wording, such as “There is 1 result” and “There are 2 results”.
  - Added status semantics so updates are announced reliably to assistive technologies.

- **Bug Fixes**
  - Filtered lists now keep accessible count wording synchronised when results change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->