### PR TITLE
Use .env.test when running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from typing import Generator, Dict, List, Union
 from contextlib import contextmanager
+from pathlib import Path
 import os
 
 import pytest
@@ -43,12 +44,14 @@ from tests.utils.database import (
 
 logger = logging.getLogger(__name__)
 
+ENV_TEST_PATH = Path(__file__).resolve().parent.parent / ".env.test"
+
 
 @pytest.fixture(scope="session")
 def test_settings():
     from dotenv import load_dotenv
 
-    load_dotenv(override=True)
+    load_dotenv(dotenv_path=ENV_TEST_PATH, override=True)
 
     # Provide test-safe defaults for required settings that tests don't actually
     # invoke — prevents ValidationError when running without a .env file.
@@ -93,6 +96,14 @@ def _maintenance_engine(database_url: str):
 def create_db(test_settings) -> PostgresDsn:
     database_url = os.environ["WRITE_DATABASE_URL"]
     engine, db_name = _maintenance_engine(database_url)
+
+    if not db_name or "test" not in db_name.lower():
+        engine.dispose()
+        raise RuntimeError(
+            f'Refusing to drop database "{db_name}": name must contain "test". '
+            "Ensure you have a .env.test file containing a database name "
+            'with "test" in it.'
+        )
 
     with engine.connect() as conn:
         conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}" WITH (FORCE)'))
@@ -462,7 +473,7 @@ def run_server():
 def mock_settings() -> Settings:
     from dotenv import load_dotenv
 
-    load_dotenv(override=True)
+    load_dotenv(dotenv_path=ENV_TEST_PATH, override=True)
     get_settings.cache_clear()
     return Settings()
 


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

The local DB keeps getting dropped when running tests since the test code creates and seeds a fresh db instance and then drops it again. We used to use the method being introduced in this PR with `.env.test` in a previous version of the code, and it's still [referenced to within the README](https://github.com/digital-land/digital-land.info/blob/e113eb08cc1d06404b57f30e624938df8295813e/README.md#L23) where it advises developers to create the file for this exact reason, but it's not clear from the documented history why it changed. 

This change isolates local development db from test db, so that we can run the current actions against the test db and not impact any local db that is used for development. CI pipeline already uses a test DB and is unaffected.

`ENV_TEST_PATH` is set to the root of the repo to ensure .env.test can be found regardless of where pytest is invoked from.

**Example .env.test config:**
```.env
READ_DATABASE_URL=postgresql://postgres:postgres@localhost/digital_land_test
WRITE_DATABASE_URL=postgresql://postgres:postgres@localhost/digital_land_test
```

**Existing README instructions:**

> ### Running the application
>  
> Create a virtualenv, then setup some environment variables. Copy `.env.example` to `.env`.
> 
> Note that to run tests you'll want a `.env.test` file as well to override db connection strings for local test. For
> example, I have a digital_land_test db to run integration tests with and override \*\_DATABASE_URL variables using the `.env.test` file.


**Changes:**
- load .env.test for test runs

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [X] No, and this is why: _It is test config, tested by the existing tests themselves_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Test runs now consistently load settings from the dedicated test environment configuration, regardless of the working directory.
  - Database setup validates that the configured database is a test database before performing destructive operations.
  - Database resources are cleaned up before reporting a blocked operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->